### PR TITLE
Add recipe deletion with failed import banners

### DIFF
--- a/.claude/rules/git.md
+++ b/.claude/rules/git.md
@@ -1,0 +1,6 @@
+# Git Commit Messages
+
+When creating git commits:
+
+- Keep commit messages clear and focused on what changed and why
+- Follow conventional commit message format when appropriate

--- a/.claude/rules/ios.md
+++ b/.claude/rules/ios.md
@@ -1,0 +1,31 @@
+---
+paths: ["hauptgang-ios/**/*"]
+---
+
+# iOS App (hauptgang-ios)
+
+The iOS app is a native SwiftUI application located in `hauptgang-ios/`.
+
+## XcodeGen
+
+This project uses **XcodeGen** to generate the Xcode project from `project.yml`. This eliminates manual `project.pbxproj` editing.
+
+**IMPORTANT**: Never manually edit `Hauptgang.xcodeproj/project.pbxproj`. It is generated and will be overwritten.
+
+## iOS Development Commands
+
+```bash
+# Run iOS tests (from project root)
+bin/ios-test
+
+# Regenerate Xcode project (from hauptgang-ios/)
+cd hauptgang-ios && xcodegen generate
+```
+
+## Adding New Swift Files
+
+1. Create the `.swift` file in the appropriate directory under `Hauptgang/`
+2. Run `xcodegen generate` to update the project
+3. Open Xcode or refresh if already open
+
+The `project.yml` auto-discovers all `.swift` files, so no configuration changes are needed.

--- a/.claude/rules/ruby-style.md
+++ b/.claude/rules/ruby-style.md
@@ -1,0 +1,7 @@
+# Code Style
+
+This project uses **rubocop-rails-omakase** for Ruby styling, which provides standardized Rails conventions from Basecamp/37signals. Follow these standards when writing code.
+
+## CI Requirements
+
+Run `bin/ci` before committing. All checks (style, security audits, tests) must pass before merging.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,50 +31,6 @@ bin/ios-test                 # Run iOS tests (auto-finds simulator, macOS only)
 # Standard Rails commands for database, testing, etc. work as expected
 ```
 
-## Code Style
-
-This project uses **rubocop-rails-omakase** for Ruby styling, which provides standardized Rails conventions from Basecamp/37signals. Follow these standards when writing code.
-
-## Git Commit Messages
-
-When creating git commits:
-
-- **DO NOT** include "Co-Authored-By: Claude" or any similar AI attribution in commit messages
-- Keep commit messages clear and focused on what changed and why
-- Follow conventional commit message format when appropriate
-
-## CI Requirements
-
-Run `bin/ci` before committing. All checks (style, security audits, tests) must pass before merging.
-
 ## Task Management
 
 Use `/dex` to break down complex work, track progress across sessions, and coordinate multi-step implementations.
-
-## iOS App (hauptgang-ios)
-
-The iOS app is a native SwiftUI application located in `hauptgang-ios/`.
-
-### XcodeGen
-
-This project uses **XcodeGen** to generate the Xcode project from `project.yml`. This eliminates manual `project.pbxproj` editing.
-
-**IMPORTANT**: Never manually edit `Hauptgang.xcodeproj/project.pbxproj`. It is generated and will be overwritten.
-
-### iOS Development Commands
-
-```bash
-# Run iOS tests (from project root)
-bin/ios-test
-
-# Regenerate Xcode project (from hauptgang-ios/)
-cd hauptgang-ios && xcodegen generate
-```
-
-### Adding New Swift Files
-
-1. Create the `.swift` file in the appropriate directory under `Hauptgang/`
-2. Run `xcodegen generate` to update the project
-3. Open Xcode or refresh if already open
-
-The `project.yml` auto-discovers all `.swift` files, so no configuration changes are needed.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.21.1)
       msgpack (~> 1.2)
-    brakeman (7.1.2)
+    brakeman (8.0.1)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)

--- a/app/controllers/api/v1/recipes_controller.rb
+++ b/app/controllers/api/v1/recipes_controller.rb
@@ -67,6 +67,7 @@ module Api
           cook_time: recipe.cook_time,
           favorite: recipe.favorite,
           cover_image_url: cover_image_url(recipe, :thumbnail),
+          import_status: recipe.import_status,
           updated_at: recipe.updated_at
         }
       end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -2,9 +2,11 @@ module Api
   module V1
     class SessionsController < BaseController
       skip_before_action :authenticate_with_token!, only: :create
-      rate_limit to: 10, within: 3.minutes, only: :create, with: -> {
-        render json: { error: "Too many login attempts. Try again later." }, status: :too_many_requests
-      }
+      unless Rails.env.local?
+        rate_limit to: 10, within: 3.minutes, only: :create, with: -> {
+          render json: { error: "Too many login attempts. Try again later." }, status: :too_many_requests
+        }
+      end
 
       def create
         user = User.authenticate_by(

--- a/app/jobs/recipe_import_job.rb
+++ b/app/jobs/recipe_import_job.rb
@@ -14,12 +14,41 @@ class RecipeImportJob < ApplicationJob
     if result.success?
       recipe.update!(result.recipe_attributes.merge(import_status: :completed))
     else
-      recipe.update!(import_status: :failed)
+      error_message = build_error_message(source_url, result.error_code)
+      recipe.update!(
+        import_status: :failed,
+        error_message: error_message
+      )
       Rails.logger.error "[RecipeImportJob] Import failed for recipe #{recipe_id}: #{result.error}"
     end
   rescue => e
-    recipe&.update(import_status: :failed)
+    if recipe
+      error_message = build_error_message(source_url, :unexpected_error)
+      recipe.update(
+        import_status: :failed,
+        error_message: error_message
+      )
+    end
     Rails.logger.error "[RecipeImportJob] Unexpected error for recipe #{recipe_id}: #{e.class} - #{e.message}"
     raise
+  end
+
+  private
+
+  def build_error_message(url, error_code)
+    domain = extract_domain(url)
+
+    # Generic message covers all failure types
+    # (no JSON-LD, LLM timeout, fetch errors, etc.)
+    "Import from #{domain} failed - page is not supported or doesn't contain a recipe"
+  end
+
+  def extract_domain(url)
+    return "unknown source" if url.blank?
+
+    uri = URI.parse(url)
+    uri.host || "unknown source"
+  rescue URI::InvalidURIError
+    "unknown source"
   end
 end

--- a/app/jobs/recipe_import_job.rb
+++ b/app/jobs/recipe_import_job.rb
@@ -37,17 +37,15 @@ class RecipeImportJob < ApplicationJob
 
   def build_error_message(url, error_code)
     domain = extract_domain(url)
-
-    # Generic message covers all failure types
-    # (no JSON-LD, LLM timeout, fetch errors, etc.)
-    "Import from #{domain} failed - page is not supported or doesn't contain a recipe"
+    "Import from #{domain} failed."
   end
 
   def extract_domain(url)
     return "unknown source" if url.blank?
 
     uri = URI.parse(url)
-    uri.host || "unknown source"
+    host = uri.host || "unknown source"
+    host.delete_prefix("www.")
   rescue URI::InvalidURIError
     "unknown source"
   end

--- a/app/jobs/recipe_text_extract_job.rb
+++ b/app/jobs/recipe_text_extract_job.rb
@@ -1,7 +1,7 @@
-class RecipeImportJob < ApplicationJob
+class RecipeTextExtractJob < ApplicationJob
   queue_as :default
 
-  def perform(user_id, recipe_id, source_url)
+  def perform(user_id, recipe_id, text)
     user = User.find_by(id: user_id)
     return unless user
 
@@ -9,17 +9,17 @@ class RecipeImportJob < ApplicationJob
     return unless recipe
     return if recipe.completed?
 
-    result = RecipeImporter.new(source_url).import
+    result = RecipeLlmService.new(text, prompt_type: :raw_text).extract
 
     if result.success?
       recipe.update!(result.recipe_attributes.merge(import_status: :completed))
     else
       recipe.update!(import_status: :failed)
-      Rails.logger.error "[RecipeImportJob] Import failed for recipe #{recipe_id}: #{result.error}"
+      Rails.logger.error "[RecipeTextExtractJob] Extraction failed for recipe #{recipe_id}: #{result.error}"
     end
   rescue => e
     recipe&.update(import_status: :failed)
-    Rails.logger.error "[RecipeImportJob] Unexpected error for recipe #{recipe_id}: #{e.class} - #{e.message}"
+    Rails.logger.error "[RecipeTextExtractJob] Unexpected error for recipe #{recipe_id}: #{e.class} - #{e.message}"
     raise
   end
 end

--- a/app/jobs/recipe_text_extract_job.rb
+++ b/app/jobs/recipe_text_extract_job.rb
@@ -16,14 +16,14 @@ class RecipeTextExtractJob < ApplicationJob
     else
       recipe.update!(
         import_status: :failed,
-        error_message: "Import failed - text doesn't contain a recipe"
+        error_message: "Import failed."
       )
       Rails.logger.error "[RecipeTextExtractJob] Extraction failed for recipe #{recipe_id}: #{result.error}"
     end
   rescue => e
     recipe&.update(
       import_status: :failed,
-      error_message: "Import failed - text doesn't contain a recipe"
+      error_message: "Import failed."
     )
     Rails.logger.error "[RecipeTextExtractJob] Unexpected error for recipe #{recipe_id}: #{e.class} - #{e.message}"
     raise

--- a/app/jobs/recipe_text_extract_job.rb
+++ b/app/jobs/recipe_text_extract_job.rb
@@ -14,11 +14,17 @@ class RecipeTextExtractJob < ApplicationJob
     if result.success?
       recipe.update!(result.recipe_attributes.merge(import_status: :completed))
     else
-      recipe.update!(import_status: :failed)
+      recipe.update!(
+        import_status: :failed,
+        error_message: "Import failed - text doesn't contain a recipe"
+      )
       Rails.logger.error "[RecipeTextExtractJob] Extraction failed for recipe #{recipe_id}: #{result.error}"
     end
   rescue => e
-    recipe&.update(import_status: :failed)
+    recipe&.update(
+      import_status: :failed,
+      error_message: "Import failed - text doesn't contain a recipe"
+    )
     Rails.logger.error "[RecipeTextExtractJob] Unexpected error for recipe #{recipe_id}: #{e.class} - #{e.message}"
     raise
   end

--- a/app/services/recipe_importers/llm_extractor.rb
+++ b/app/services/recipe_importers/llm_extractor.rb
@@ -1,25 +1,12 @@
 require "nokogiri"
-require "ruby_llm/schema"
 
 module RecipeImporters
-  # Extracts recipe data from HTML using LLM when JSON-LD is not available
+  # Extracts recipe data from HTML using LLM when JSON-LD is not available.
+  # Handles HTML preprocessing (cleaning) and delegates LLM extraction to RecipeLlmService.
   class LlmExtractor
     Result = RecipeImporter::Result
 
-    # Schema for structured LLM output
-    class RecipeSchema < RubyLLM::Schema
-      string :name, description: "Recipe title"
-      array :ingredients, of: :string, description: "List of ingredients with quantities"
-      array :instructions, of: :string, description: "Step-by-step cooking instructions"
-      integer :prep_time, required: false, description: "Preparation time in minutes"
-      integer :cook_time, required: false, description: "Cooking time in minutes"
-      integer :servings, required: false, description: "Number of servings"
-      string :notes, required: false, description: "Recipe description or notes"
-    end
-
-    MAX_TEXT_LENGTH = 15_000
     REMOVABLE_TAGS = %w[script style nav header footer aside noscript iframe svg].freeze
-    MODEL = "openai/gpt-oss-20b"
 
     def initialize(html, source_url)
       @html = html
@@ -30,71 +17,20 @@ module RecipeImporters
       cleaned_text = clean_html
       return extraction_failed("Could not extract text content from page") if cleaned_text.blank?
 
-      response = call_llm(cleaned_text)
-      build_result(response.content)
-    rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
-      Result.new(success?: false, recipe_attributes: {}, error: "LLM request timed out: #{e.message}", error_code: :llm_timeout)
-    rescue RubyLLM::Error => e
-      Result.new(success?: false, recipe_attributes: {}, error: "LLM API error: #{e.message}", error_code: :llm_error)
-    rescue StandardError => e
-      Result.new(success?: false, recipe_attributes: {}, error: "Extraction failed: #{e.message}", error_code: :extraction_failed)
+      service_result = RecipeLlmService.new(cleaned_text, prompt_type: :webpage, source_url: @source_url).extract
+      convert_result(service_result)
     end
 
     private
 
     def clean_html
       doc = Nokogiri::HTML(@html)
-
-      # Remove non-content elements
       REMOVABLE_TAGS.each { |tag| doc.css(tag).remove }
-
-      # Extract text and normalize whitespace
-      text = doc.text.gsub(/\s+/, " ").strip
-      text[0, MAX_TEXT_LENGTH]
+      doc.text.gsub(/\s+/, " ").strip
     end
 
-    def call_llm(text)
-      chat = RubyLLM.chat(model: MODEL, provider: :openrouter)
-      chat.with_schema(RecipeSchema).ask(prompt_for(text))
-    end
-
-    def prompt_for(text)
-      <<~PROMPT
-        Extract recipe information from the following webpage content.
-        Find the recipe name, ingredients list, and cooking instructions.
-
-        If you cannot find recipe content, return an empty name field.
-
-        Webpage content:
-        ---
-        #{text}
-        ---
-      PROMPT
-    end
-
-    def build_result(content)
-      return extraction_failed("No recipe data returned") if content.blank?
-
-      name = content["name"].to_s.strip
-      return extraction_failed("Could not identify recipe name") if name.blank?
-
-      attributes = {
-        name: name,
-        ingredients: normalize_array(content["ingredients"]),
-        instructions: normalize_array(content["instructions"]),
-        prep_time: content["prep_time"],
-        cook_time: content["cook_time"],
-        servings: content["servings"],
-        notes: content["notes"].to_s.strip.presence,
-        source_url: @source_url
-      }
-
-      Result.new(success?: true, recipe_attributes: attributes, error: nil, error_code: nil)
-    end
-
-    def normalize_array(arr)
-      return [] unless arr.is_a?(Array)
-      arr.map { |item| item.to_s.strip }.reject(&:blank?)
+    def convert_result(service_result)
+      Result.new(**service_result.to_h)
     end
 
     def extraction_failed(message)

--- a/app/services/recipe_llm_service.rb
+++ b/app/services/recipe_llm_service.rb
@@ -1,0 +1,120 @@
+require "ruby_llm/schema"
+
+# Extracts recipe data from text using an LLM.
+# Supports extraction from webpage content or raw recipe text.
+class RecipeLlmService
+  Result = Data.define(:success?, :recipe_attributes, :error, :error_code)
+
+  class RecipeSchema < RubyLLM::Schema
+    string :name, description: "Recipe title"
+    array :ingredients, of: :string, description: "List of ingredients with quantities"
+    array :instructions, of: :string, description: "Step-by-step cooking instructions"
+    integer :prep_time, required: false, description: "Preparation time in minutes"
+    integer :cook_time, required: false, description: "Cooking time in minutes"
+    integer :servings, required: false, description: "Number of servings"
+    string :notes, required: false, description: "Recipe description or notes"
+  end
+
+  MAX_TEXT_LENGTH = 15_000
+  MODEL = "openai/gpt-oss-20b"
+  PROMPT_TYPES = %i[webpage raw_text].freeze
+
+  def initialize(text, prompt_type: :webpage, source_url: nil)
+    raise ArgumentError, "Invalid prompt_type: #{prompt_type}" unless PROMPT_TYPES.include?(prompt_type)
+
+    @text = text
+    @prompt_type = prompt_type
+    @source_url = source_url
+  end
+
+  def extract
+    truncated_text = @text.to_s[0, MAX_TEXT_LENGTH]
+    return extraction_failed("No text content provided") if truncated_text.blank?
+
+    response = call_llm(truncated_text)
+    build_result(response.content)
+  rescue Faraday::TimeoutError, Faraday::ConnectionFailed => e
+    error_result("LLM request timed out: #{e.message}", :llm_timeout)
+  rescue RubyLLM::Error => e
+    error_result("LLM API error: #{e.message}", :llm_error)
+  rescue StandardError => e
+    error_result("Extraction failed: #{e.message}", :extraction_failed)
+  end
+
+  private
+
+  def call_llm(text)
+    chat = RubyLLM.chat(model: MODEL, provider: :openrouter)
+    chat.with_schema(RecipeSchema).ask(prompt_for(text))
+  end
+
+  def prompt_for(text)
+    case @prompt_type
+    when :webpage
+      webpage_prompt(text)
+    when :raw_text
+      raw_text_prompt(text)
+    end
+  end
+
+  def webpage_prompt(text)
+    <<~PROMPT
+      Extract recipe information from the following webpage content.
+      Find the recipe name, ingredients list, and cooking instructions.
+
+      If you cannot find recipe content, return an empty name field.
+
+      Webpage content:
+      ---
+      #{text}
+      ---
+    PROMPT
+  end
+
+  def raw_text_prompt(text)
+    <<~PROMPT
+      Extract recipe information from the following text.
+      Parse the recipe name, ingredients list, and cooking instructions.
+
+      If the text does not contain a valid recipe, return an empty name field.
+
+      Recipe text:
+      ---
+      #{text}
+      ---
+    PROMPT
+  end
+
+  def build_result(content)
+    return extraction_failed("No recipe data returned") if content.blank?
+
+    name = content["name"].to_s.strip
+    return extraction_failed("Could not identify recipe name") if name.blank?
+
+    attributes = {
+      name: name,
+      ingredients: normalize_array(content["ingredients"]),
+      instructions: normalize_array(content["instructions"]),
+      prep_time: content["prep_time"],
+      cook_time: content["cook_time"],
+      servings: content["servings"],
+      notes: content["notes"].to_s.strip.presence
+    }
+    attributes[:source_url] = @source_url if @source_url.present?
+
+    Result.new(success?: true, recipe_attributes: attributes, error: nil, error_code: nil)
+  end
+
+  def normalize_array(arr)
+    return [] unless arr.is_a?(Array)
+    arr.map { |item| item.to_s.strip }.reject(&:blank?)
+  end
+
+  def extraction_failed(message)
+    error_result(message, :extraction_failed)
+  end
+
+  def error_result(message, code)
+    Result.new(success?: false, recipe_attributes: {}, error: message, error_code: code)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
         resource :favorite, only: [ :update, :destroy ]
         collection do
           post :import
+          post :extract_from_text
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resource :session, only: [ :create, :destroy ]
-      resources :recipes, only: [ :index, :show ] do
+      resources :recipes, only: [ :index, :show, :destroy ] do
         resource :favorite, only: [ :update, :destroy ]
         collection do
           post :import

--- a/db/migrate/20260130114058_add_error_fields_to_recipes.rb
+++ b/db/migrate/20260130114058_add_error_fields_to_recipes.rb
@@ -1,0 +1,6 @@
+class AddErrorFieldsToRecipes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :recipes, :error_message, :text
+    add_column :recipes, :failed_recipe_fetched_at, :datetime
+  end
+end

--- a/db/migrate/20260130114933_backfill_failed_recipe_errors.rb
+++ b/db/migrate/20260130114933_backfill_failed_recipe_errors.rb
@@ -1,0 +1,11 @@
+class BackfillFailedRecipeErrors < ActiveRecord::Migration[8.1]
+  def up
+    # Delete existing failed recipes for a clean slate
+    # These recipes are stuck in a bad state without error messages
+    Recipe.where(import_status: :failed).destroy_all
+  end
+
+  def down
+    # No-op: Can't restore deleted recipes
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_30_114058) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_30_114933) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_01_27_105314) do
+ActiveRecord::Schema[8.1].define(version: 2026_01_30_114058) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -65,6 +65,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_01_27_105314) do
   create_table "recipes", force: :cascade do |t|
     t.integer "cook_time"
     t.datetime "created_at", null: false
+    t.text "error_message"
+    t.datetime "failed_recipe_fetched_at"
     t.boolean "favorite", default: false
     t.integer "import_status", default: 1, null: false
     t.json "ingredients", default: []

--- a/docs/brainstorms/2026-01-30-failed-recipe-import-handling-brainstorm.md
+++ b/docs/brainstorms/2026-01-30-failed-recipe-import-handling-brainstorm.md
@@ -1,0 +1,202 @@
+# Failed Recipe Import Handling - Brainstorm
+
+**Date:** 2026-01-30
+**Status:** Ready for Planning
+
+## Problem Statement
+
+When recipe imports fail (unsupported website, no recipe data found, timeout, etc.), the recipe remains in the user's list with the name "Importing..." indefinitely. Users have no visibility into:
+- Whether the import failed
+- Why it failed
+- Which URL caused the failure
+- How to clean up failed imports
+
+This creates a poor user experience and clutters the recipe list.
+
+## What We're Building
+
+An automatic failed recipe handling system that:
+1. **Shows clear error messages** to users when imports fail, including the domain name
+2. **Displays errors prominently** as banners at the top of the recipe list
+3. **Automatically cleans up** failed recipes after ensuring the user had a chance to see them
+4. **Handles multiple failures** gracefully (multiple error banners if needed)
+
+## Why This Approach
+
+**Selected: Auto-Delete After First Fetch + Time Buffer**
+
+We chose this approach because it balances three key concerns:
+
+1. **User Awareness**: Users must see what went wrong and which URL failed
+2. **Automatic Cleanup**: No manual deletion required, keeps UI clean
+3. **Safety**: Prevents premature deletion from race conditions or rapid refreshes
+
+### How It Works
+
+**Backend (Rails):**
+- Add `error_message` TEXT and `failed_recipe_fetched_at` TIMESTAMP columns to recipes table
+- When `RecipeImportJob` fails:
+  - Set `import_status: :failed`
+  - Store user-friendly error: "Import from {domain} failed - page is not supported or doesn't contain a recipe"
+  - Leave `failed_recipe_fetched_at` as NULL
+- On `GET /recipes` (in controller):
+  - If failed recipe has `fetched_at = nil`, set it to `Time.current` (first fetch)
+  - If failed recipe has `fetched_at` older than 1 minute, delete it (using `after_action`)
+- Return failed recipes in normal JSON response with error message
+
+**Frontend (iOS):**
+- Receive all recipes including failed ones from API
+- Filter recipes into two groups:
+  - `failedRecipes`: where `importStatus == "failed"`
+  - `successfulRecipes`: all others
+- Display failed recipes as error banners at **top** of list
+- Display successful recipes as normal cards below banners
+- Each error banner shows the recipe's `errorMessage` field
+- Multiple failed imports → Multiple banners (one per failure)
+
+### Timing Logic
+
+1. Import fails → Recipe created with status `failed`, `fetched_at = nil`
+2. iOS polls (GET /recipes) → Backend sees `fetched_at = nil`, sets to now
+3. iOS shows error banner(s) for at least 1 minute
+4. iOS polls again after 1+ minute → Backend deletes recipe, returns updated list
+5. Error banner(s) disappear from UI
+
+## Key Decisions
+
+### 1. Error Message Format
+**Decision:** "Import from {domain} failed - page is not supported or doesn't contain a recipe"
+
+**Rationale:**
+- Includes domain so user knows which URL failed
+- Generic enough to cover all failure types (no JSON-LD, LLM timeout, fetch errors)
+- Friendly and non-technical language
+
+**Edge case:** Text imports (no URL) → Show "Import failed - text doesn't contain a recipe"
+
+### 2. Display Location
+**Decision:** Error banners at top of recipe list (not integrated into recipe cards)
+
+**Rationale:**
+- More prominent and noticeable
+- Clearly separates temporary errors from permanent recipes
+- Easy to understand multiple failures
+- Doesn't clutter main recipe grid/list
+
+### 3. Deletion Timing
+**Decision:** Delete after first fetch + 1 minute minimum
+
+**Rationale:**
+- **First fetch tracking**: Ensures error was delivered to at least one device
+- **1 minute buffer**: Handles rapid refreshes, app backgrounding, multiple devices
+- Prevents deletion from:
+  - Polling every 3 seconds during import
+  - User quickly opening/closing app
+  - Multiple devices fetching simultaneously
+
+### 4. Error Message Storage
+**Decision:** Add `error_message` column instead of just using enum status
+
+**Rationale:**
+- Backend already generates detailed error codes (`:no_json_ld`, `:timeout`, etc.)
+- Can map error codes to user-friendly messages
+- Includes dynamic content (domain name)
+- Future-proof for localization or more detailed errors
+
+## Alternatives Considered
+
+### Time-Based Auto-Delete (5 minutes)
+**Why not chosen:**
+- Less reliable - might delete before user sees it
+- Arbitrary timeout (5 min too long? too short?)
+- Doesn't adapt to user behavior (e.g., user opens app after 10 minutes)
+
+### User-Dismissed Errors (Manual deletion)
+**Why not chosen:**
+- Adds friction - requires user action
+- More complex iOS UI (dismiss buttons)
+- Failed imports accumulate if user ignores them
+- Breaks the "automatic cleanup" goal
+
+### Immediate Deletion (No user visibility)
+**Why not chosen:**
+- Users don't learn which sites work/don't work
+- Mystery failures ("I tried importing but nothing happened")
+- No feedback loop for reporting issues
+
+## Open Questions
+
+### Technical Details
+1. **Error code mapping:** How should we map backend error codes to user messages?
+   - Option A: All failures show same generic message (simpler)
+   - Option B: Different messages for timeout vs no-recipe vs fetch-failed (more helpful)
+
+2. **Domain extraction:** Should we extract domain in backend or iOS?
+   - Recommendation: Backend (in `RecipeImportJob`) - keeps logic centralized
+
+3. **Migration strategy:** What happens to existing failed recipes with no error message?
+   - Recommendation: Backfill with generic "Import failed" or delete immediately
+
+4. **Polling optimization:** Should we stop polling when only failed recipes remain?
+   - Current: Polls until no "pending" recipes
+   - With this change: Failed recipes aren't pending, so polling already stops correctly
+
+### iOS Implementation
+5. **Banner styling:** Should banners be dismissible, or just show info?
+   - Recommendation: Info-only (auto-disappears after 1 min)
+
+6. **Multiple failures UI:** Stack banners vertically, or show count?
+   - Option A: Stack all banners (clear but takes space)
+   - Option B: Single banner "3 imports failed" with expansion (compact)
+   - Recommendation: Start with Option A (simpler)
+
+7. **Error icon:** What SF Symbol to use for error banners?
+   - Recommendation: `exclamationmark.triangle.fill` (standard warning icon)
+
+### Edge Cases
+8. **User never opens app:** If failed recipe created but user doesn't open app for days?
+   - Current plan: Recipe stays until fetched once
+   - Alternative: Add fallback cleanup (delete after 7 days regardless)
+
+9. **Multiple devices with time skew:** What if device A fetches, device B fetches 30s later?
+   - Current plan: First fetch sets timestamp, second device sees existing timestamp
+   - Works correctly - buffer time handles this
+
+10. **Concurrent imports failing:** 5 recipes imported simultaneously, all fail?
+    - Current plan: 5 error banners shown
+    - Need to ensure iOS UI handles this gracefully (scrolling, spacing)
+
+## Success Criteria
+
+We'll know this is working when:
+1. ✅ Users see clear error messages when imports fail
+2. ✅ Error messages include the domain name that failed
+3. ✅ Failed recipes auto-delete after ~1 minute
+4. ✅ No failed recipes accumulate in the list long-term
+5. ✅ Multiple failures display clearly (stacked banners)
+6. ✅ No premature deletion from rapid refreshes
+7. ✅ Works correctly across multiple devices
+
+## Files That Will Change
+
+### Backend (Rails)
+- `db/migrate/TIMESTAMP_add_error_fields_to_recipes.rb` - New migration
+- `app/models/recipe.rb` - Add scopes for deletion logic
+- `app/jobs/recipe_import_job.rb` - Store error messages on failure
+- `app/controllers/api/v1/recipes_controller.rb` - Track fetch time, delete old failures
+- `app/services/recipe_importer.rb` - Maybe refine error messages (optional)
+
+### Frontend (iOS)
+- `hauptgang-ios/Hauptgang/Models/Recipe.swift` - Add `errorMessage` field
+- `hauptgang-ios/Hauptgang/Views/RecipesView.swift` - Filter and display banners
+- `hauptgang-ios/Hauptgang/Views/ErrorBannerView.swift` - **New file** for banner component
+- `hauptgang-ios/Hauptgang/ViewModels/RecipeViewModel.swift` - Handle failed recipes in logic
+
+## Next Steps
+
+Ready for `/workflows:plan` to design detailed implementation with:
+- Database migration SQL
+- Exact error message mapping logic
+- iOS banner component design (spacing, colors, SF Symbols)
+- Testing strategy for edge cases
+- Deployment considerations (existing failed recipes)

--- a/docs/plans/2026-01-30-feat-failed-recipe-import-handling-plan.md
+++ b/docs/plans/2026-01-30-feat-failed-recipe-import-handling-plan.md
@@ -774,7 +774,7 @@ func testPollingDoesNotTriggerForFailedRecipes() {
 - [x] Update `RecipesController#index`: Add `track_failed_recipe_fetches` call
 - [x] Update `RecipesController`: Add `after_action :cleanup_old_failed_recipes`
 - [x] Update `RecipesController#recipe_list_json`: Include `error_message` field
-- [ ] Create data migration: Clean up existing failed recipes
+- [x] Create data migration: Clean up existing failed recipes
 - [x] Write backend tests for error message storage
 - [x] Write backend tests for fetch tracking
 - [x] Write backend tests for cleanup timing
@@ -783,10 +783,10 @@ func testPollingDoesNotTriggerForFailedRecipes() {
 
 ### iOS Tasks
 
-- [ ] Update `Recipe.swift`: Add `errorMessage: String?` to `RecipeListItem`
-- [ ] Update `PersistedRecipe.swift`: Add `errorMessage` field
-- [ ] Update `PersistedRecipe.swift`: Update convenience initializers
-- [ ] Update `PersistedRecipe.swift`: Update `update(from:)` method
+- [x] Update `Recipe.swift`: Add `errorMessage: String?` to `RecipeListItem`
+- [x] Update `PersistedRecipe.swift`: Add `errorMessage` field
+- [x] Update `PersistedRecipe.swift`: Update convenience initializers
+- [x] Update `PersistedRecipe.swift`: Update `update(from:)` method
 - [ ] Create `ErrorBannerView.swift`: Implement banner component
 - [ ] Add SwiftUI previews to `ErrorBannerView.swift` (single + multiple errors)
 - [ ] Update `RecipesView.swift`: Add failed recipe banners to layout

--- a/docs/plans/2026-01-30-feat-failed-recipe-import-handling-plan.md
+++ b/docs/plans/2026-01-30-feat-failed-recipe-import-handling-plan.md
@@ -1,0 +1,871 @@
+---
+title: Implement Failed Recipe Import Handling with Auto-Cleanup
+type: feat
+date: 2026-01-30
+---
+
+# Implement Failed Recipe Import Handling with Auto-Cleanup
+
+## Overview
+
+When recipe imports fail (unsupported website, no recipe data, timeout, etc.), the recipe currently remains in the user's list with "Importing..." indefinitely. This feature adds automatic failed recipe handling that shows clear error messages to users and automatically cleans up failed imports after ensuring users had a chance to see them.
+
+**Solution**: Display failed recipes as error banners at the top of the recipe list, include the domain name that failed, and auto-delete after the first fetch + 1 minute buffer.
+
+## Problem Statement
+
+**Current Behavior:**
+- Failed imports show "Importing..." forever
+- No visibility into failures or reasons
+- No way to clean up failed recipes
+- Clutters the recipe list
+
+**Impact on Users:**
+- Confusion about import status
+- No feedback on which sites work/don't work
+- Manual cleanup burden (requires database access)
+- Poor user experience
+
+## Proposed Solution
+
+### High-Level Approach
+
+**Backend (Rails):**
+1. Add `error_message` (TEXT) and `failed_recipe_fetched_at` (TIMESTAMP) columns
+2. Store user-friendly error messages when imports fail (include domain)
+3. Track first fetch time of failed recipes
+4. Auto-delete failed recipes after 1+ minute post-fetch
+
+**Frontend (iOS):**
+1. Receive failed recipes with error messages from API
+2. Filter recipes into failed and successful groups
+3. Display failed recipes as error banners at top of list
+4. Display successful recipes as normal cards below
+5. Banners disappear automatically when backend deletes recipes
+
+### Timing Logic
+
+```
+1. Import fails
+   → Recipe created: status=failed, fetched_at=nil, error_message="Import from example.com failed..."
+
+2. iOS polls (GET /recipes)
+   → Backend: fetched_at=nil? Set to now
+   → iOS: Shows error banner
+
+3. User sees error for 1+ minute
+   → iOS continues normal polling
+
+4. iOS polls again (after 1+ minute)
+   → Backend: fetched_at < 1.minute.ago? Delete recipe
+   → iOS: Error banner disappears
+```
+
+## Technical Approach
+
+### Backend Implementation
+
+#### 1. Database Migration
+
+**File**: `db/migrate/TIMESTAMP_add_error_fields_to_recipes.rb`
+
+```ruby
+class AddErrorFieldsToRecipes < ActiveRecord::Migration[8.1]
+  def change
+    add_column :recipes, :error_message, :text, null: true
+    add_column :recipes, :failed_recipe_fetched_at, :datetime, null: true
+  end
+end
+```
+
+**Rationale:**
+- `:text` for potentially long error strings (domain + message)
+- `:datetime` for timestamp tracking
+- `null: true` since only failed recipes need these fields
+
+#### 2. Error Message Generation in RecipeImportJob
+
+**File**: `app/jobs/recipe_import_job.rb` (modify lines 13-18)
+
+**Current Code:**
+```ruby
+if result.success?
+  recipe.update!(result.recipe_attributes.merge(import_status: :completed))
+else
+  recipe.update!(import_status: :failed)
+  Rails.logger.error "[RecipeImportJob] Import failed for recipe #{recipe_id}: #{result.error}"
+end
+```
+
+**New Code:**
+```ruby
+if result.success?
+  recipe.update!(result.recipe_attributes.merge(import_status: :completed))
+else
+  error_message = build_error_message(source_url, result.error_code)
+  recipe.update!(
+    import_status: :failed,
+    error_message: error_message
+  )
+  Rails.logger.error "[RecipeImportJob] Import failed for recipe #{recipe_id}: #{result.error}"
+end
+```
+
+**Add Helper Method:**
+```ruby
+private
+
+def build_error_message(url, error_code)
+  domain = extract_domain(url)
+
+  # Generic message covers all failure types
+  # (no JSON-LD, LLM timeout, fetch errors, etc.)
+  "Import from #{domain} failed - page is not supported or doesn't contain a recipe"
+end
+
+def extract_domain(url)
+  return "unknown source" if url.blank?
+
+  uri = URI.parse(url)
+  uri.host || "unknown source"
+rescue URI::InvalidURIError
+  "unknown source"
+end
+```
+
+**Also Update RecipeTextExtractJob** (lines 17-18):
+```ruby
+else
+  error_message = "Import failed - text doesn't contain a recipe"
+  recipe.update!(
+    import_status: :failed,
+    error_message: error_message
+  )
+end
+```
+
+#### 3. Controller Changes for Fetch Tracking & Cleanup
+
+**File**: `app/controllers/api/v1/recipes_controller.rb`
+
+**Modify `index` action** (after line 7):
+```ruby
+def index
+  recipes = current_user.recipes.with_attached_cover_image.includes(:tags)
+  recipes = recipes.favorited if params[:favorites] == "true"
+  recipes = recipes.order(updated_at: :desc)
+
+  # Track first fetch of failed recipes (before rendering)
+  track_failed_recipe_fetches(recipes)
+
+  render json: recipes.map { |recipe| recipe_list_json(recipe) }
+end
+```
+
+**Add Helper Methods:**
+```ruby
+private
+
+def track_failed_recipe_fetches(recipes)
+  # Find failed recipes that haven't been fetched yet
+  unfetched_failed = recipes.select do |recipe|
+    recipe.failed? && recipe.failed_recipe_fetched_at.nil?
+  end
+
+  # Mark them as fetched now
+  unfetched_failed.each do |recipe|
+    recipe.update_column(:failed_recipe_fetched_at, Time.current)
+  end
+end
+```
+
+**Add `after_action` hook** (after line 3):
+```ruby
+after_action :cleanup_old_failed_recipes, only: [:index]
+
+private
+
+def cleanup_old_failed_recipes
+  # Delete failed recipes that were fetched more than 1 minute ago
+  current_user.recipes
+    .where(import_status: :failed)
+    .where("failed_recipe_fetched_at < ?", 1.minute.ago)
+    .destroy_all
+end
+```
+
+**Update `recipe_list_json` helper** (line 70):
+```ruby
+def recipe_list_json(recipe)
+  {
+    id: recipe.id,
+    name: recipe.name,
+    prep_time: recipe.prep_time,
+    cook_time: recipe.cook_time,
+    favorite: recipe.favorite,
+    cover_image_url: cover_image_url(recipe, :thumbnail),
+    import_status: recipe.import_status,
+    error_message: recipe.error_message,  # ← NEW: nil for non-failed recipes
+    updated_at: recipe.updated_at
+  }
+end
+```
+
+**Why `after_action`?**
+- Runs after response is rendered and sent to client
+- Doesn't slow down API response time
+- Failed recipes are already in the response if they shouldn't be deleted yet
+
+**Why 1 minute buffer?**
+- Prevents deletion from rapid refreshes (iOS polls every 3 seconds during imports)
+- Handles app backgrounding/foregrounding
+- Accounts for multiple devices with slight time skew
+- Ensures error message is delivered to at least one device
+
+#### 4. Data Migration for Existing Failed Recipes
+
+**File**: `db/migrate/TIMESTAMP_backfill_failed_recipe_errors.rb`
+
+```ruby
+class BackfillFailedRecipeErrors < ActiveRecord::Migration[8.1]
+  def up
+    # Option 1: Delete existing failed recipes immediately (clean slate)
+    Recipe.where(import_status: :failed).destroy_all
+
+    # Option 2: Backfill with generic message (preserve data)
+    # Recipe.where(import_status: :failed).update_all(
+    #   error_message: "Import failed - page is not supported",
+    #   failed_recipe_fetched_at: Time.current
+    # )
+  end
+
+  def down
+    # No-op: Can't restore deleted recipes
+  end
+end
+```
+
+**Recommendation**: Use Option 1 (delete) for clean slate. Existing failed recipes are stuck in bad state anyway.
+
+### iOS Implementation
+
+#### 1. Update Recipe Model
+
+**File**: `hauptgang-ios/Hauptgang/Models/Recipe.swift`
+
+**Modify `RecipeListItem`** (after line 13):
+```swift
+struct RecipeListItem: Codable, Identifiable, Sendable {
+    let id: Int
+    let name: String
+    let prepTime: Int?
+    let cookTime: Int?
+    let favorite: Bool
+    let coverImageUrl: String?
+    let importStatus: String?
+    let errorMessage: String?  // ← NEW: Error text for failed imports
+    let updatedAt: Date
+}
+```
+
+**Coding Keys** (add if needed):
+```swift
+enum CodingKeys: String, CodingKey {
+    case id, name, prepTime, cookTime, favorite, coverImageUrl
+    case importStatus, errorMessage, updatedAt
+}
+```
+
+#### 2. Update Persistence Model
+
+**File**: `hauptgang-ios/Hauptgang/Models/PersistedRecipe.swift`
+
+**Add field** (after line 15):
+```swift
+@Model
+final class PersistedRecipe {
+    @Attribute(.unique) var id: Int
+    var name: String
+    var prepTime: Int?
+    var cookTime: Int?
+    var favorite: Bool
+    var coverImageUrl: String?
+    var importStatus: String?
+    var errorMessage: String?  // ← NEW: Store error from API
+    var updatedAt: Date
+    var lastFetchedAt: Date
+
+    // ... rest of fields
+}
+```
+
+**Update Convenience Initializer** (line 100):
+```swift
+convenience init(from listItem: RecipeListItem) {
+    self.init(
+        id: listItem.id,
+        name: listItem.name,
+        prepTime: listItem.prepTime,
+        cookTime: listItem.cookTime,
+        favorite: listItem.favorite,
+        coverImageUrl: listItem.coverImageUrl,
+        importStatus: listItem.importStatus,
+        errorMessage: listItem.errorMessage,  // ← NEW
+        updatedAt: listItem.updatedAt
+    )
+}
+```
+
+**Update `update(from:)` Method** (line 136):
+```swift
+func update(from listItem: RecipeListItem) {
+    name = listItem.name
+    prepTime = listItem.prepTime
+    cookTime = listItem.cookTime
+    favorite = listItem.favorite
+    coverImageUrl = listItem.coverImageUrl
+    importStatus = listItem.importStatus
+    errorMessage = listItem.errorMessage  // ← NEW
+    updatedAt = listItem.updatedAt
+    lastFetchedAt = Date()
+}
+```
+
+#### 3. Create ErrorBannerView Component
+
+**File**: `hauptgang-ios/Hauptgang/Views/ErrorBannerView.swift` (NEW FILE)
+
+```swift
+import SwiftUI
+
+struct ErrorBannerView: View {
+    let recipe: PersistedRecipe
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            // Error icon
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.title3)
+                .foregroundColor(.white)
+                .frame(width: 24)
+
+            // Error message text
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                if let errorMessage = recipe.errorMessage {
+                    Text(errorMessage)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+                        .multilineTextAlignment(.leading)
+                } else {
+                    // Fallback for recipes without error_message
+                    Text("Import failed - page is not supported")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(Theme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.CornerRadius.md)
+                .fill(Color.hauptgangError)
+        )
+        .shadow(
+            color: Color.black.opacity(0.1),
+            radius: 4,
+            x: 0,
+            y: 2
+        )
+    }
+}
+
+// MARK: - Preview
+#Preview("Single Error") {
+    ErrorBannerView(recipe: {
+        let recipe = PersistedRecipe(
+            id: 1,
+            name: "Importing...",
+            favorite: false,
+            updatedAt: Date()
+        )
+        recipe.importStatus = "failed"
+        recipe.errorMessage = "Import from allrecipes.com failed - page is not supported or doesn't contain a recipe"
+        return recipe
+    }())
+    .padding()
+}
+
+#Preview("Multiple Errors") {
+    VStack(spacing: Theme.Spacing.sm) {
+        ErrorBannerView(recipe: {
+            let recipe = PersistedRecipe(id: 1, name: "Test", favorite: false, updatedAt: Date())
+            recipe.importStatus = "failed"
+            recipe.errorMessage = "Import from allrecipes.com failed - page is not supported or doesn't contain a recipe"
+            return recipe
+        }())
+
+        ErrorBannerView(recipe: {
+            let recipe = PersistedRecipe(id: 2, name: "Test", favorite: false, updatedAt: Date())
+            recipe.importStatus = "failed"
+            recipe.errorMessage = "Import from epicurious.com failed - page is not supported or doesn't contain a recipe"
+            return recipe
+        }())
+    }
+    .padding()
+}
+```
+
+**Design Rationale:**
+- **Icon**: `exclamationmark.triangle.fill` (standard warning icon)
+- **Color**: `.hauptgangError` (red #DC2626 from theme)
+- **Layout**: Horizontal with icon on left, text on right
+- **Styling**: Rounded corners, shadow, padding matching theme constants
+- **No dismiss button**: Auto-disappears after 1 minute (backend-driven)
+
+#### 4. Update RecipesView Layout
+
+**File**: `hauptgang-ios/Hauptgang/Views/RecipesView.swift`
+
+**Modify `recipeListView`** (replace lines 51-88):
+```swift
+private var recipeListView: some View {
+    ScrollView {
+        VStack(spacing: Theme.Spacing.sm) {
+            // Global error message (API failures)
+            if let error = recipeViewModel.errorMessage {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.hauptgangError)
+                    .padding(.horizontal, Theme.Spacing.lg)
+            }
+
+            // Failed recipe error banners (NEW)
+            ForEach(recipeViewModel.failedRecipes) { recipe in
+                ErrorBannerView(recipe: recipe)
+                    .padding(.horizontal, Theme.Spacing.md)
+            }
+
+            // Successful recipe cards
+            LazyVStack(spacing: Theme.Spacing.md) {
+                ForEach(recipeViewModel.successfulRecipes) { recipe in
+                    NavigationLink(value: recipe.id) {
+                        RecipeCardView(recipe: recipe)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, Theme.Spacing.md)
+        }
+        .padding(.top, Theme.Spacing.sm)
+    }
+    .refreshable {
+        await recipeViewModel.refreshRecipes()
+    }
+}
+```
+
+**Key Changes:**
+- Split recipes into `failedRecipes` and `successfulRecipes` (computed properties)
+- Display error banners at top of list
+- Successful recipes below as normal cards
+- Removed card overlay logic for failed recipes (now using banners)
+
+#### 5. Update RecipeViewModel
+
+**File**: `hauptgang-ios/Hauptgang/ViewModels/RecipeViewModel.swift`
+
+**Add Computed Properties** (after line 15):
+```swift
+var failedRecipes: [PersistedRecipe] {
+    recipes.filter { $0.importStatus == "failed" }
+}
+
+var successfulRecipes: [PersistedRecipe] {
+    recipes.filter { $0.importStatus != "failed" }
+}
+```
+
+**No polling changes needed** - Polling already checks only `"pending"` status (line 14), so failed recipes won't trigger continuous polling.
+
+#### 6. Update RecipeCardView (Optional Cleanup)
+
+**File**: `hauptgang-ios/Hauptgang/Views/RecipeCardView.swift`
+
+**Remove failed overlay** (lines 137-158):
+```swift
+// Delete the "failed" case from importStatusOverlay method
+// Only keep "pending" case, remove entire failed block
+```
+
+**Rationale**: Failed recipes now display as banners, not cards. Pending recipes still need the spinner overlay.
+
+## Acceptance Criteria
+
+### Functional Requirements
+
+- [ ] Failed recipes display as error banners at top of recipe list
+- [ ] Error messages include domain name that failed (e.g., "Import from allrecipes.com failed...")
+- [ ] Multiple failures display as stacked banners (one per failure)
+- [ ] Error banners auto-disappear after ~1 minute
+- [ ] No failed recipes accumulate long-term in the database
+- [ ] Text-based imports show "Import failed - text doesn't contain a recipe"
+- [ ] Successful recipes display as normal cards below error banners
+
+### Non-Functional Requirements
+
+- [ ] No premature deletion from rapid refreshes (polling every 3 seconds)
+- [ ] Works correctly across multiple devices with time skew
+- [ ] Backend cleanup doesn't slow down API response time (`after_action`)
+- [ ] iOS UI handles 5+ concurrent failures gracefully (scrolling, spacing)
+- [ ] Existing failed recipes cleaned up via data migration
+
+### Quality Gates
+
+- [ ] Backend tests verify error message storage and domain extraction
+- [ ] Backend tests verify 1-minute deletion timing
+- [ ] Backend tests verify first-fetch tracking
+- [ ] iOS previews show single and multiple error banners
+- [ ] Manual testing with unsupported domains (e.g., example.com)
+- [ ] Manual testing with multiple concurrent failures
+
+## Technical Considerations
+
+### Race Condition Prevention
+
+**Problem**: Device A fetches at T+0, Device B fetches at T+30s. If we delete immediately, Device B might never see the error.
+
+**Solution**: 1-minute buffer ensures all devices have multiple polling cycles to fetch the failed recipe before deletion.
+
+**Edge Case - Clock Skew**: What if devices have slightly different system times?
+- Server time (`Time.current`) is source of truth
+- Buffer is generous enough (60 seconds) to handle skew
+- Polling continues regardless of client time
+
+### Performance Considerations
+
+**Database Queries:**
+- `track_failed_recipe_fetches`: In-memory filtering, single UPDATE per unfetched recipe
+- `cleanup_old_failed_recipes`: Single DELETE query with WHERE clause, runs after response
+- No N+1 queries (already using `includes(:tags)`)
+
+**API Response Size:**
+- Failed recipes included in normal response (adds ~100 bytes per failure)
+- Typical case: 0-2 failed recipes at a time
+- Edge case: 10+ failures → ~1KB extra (acceptable)
+
+**iOS Memory:**
+- Failed recipes stored in SwiftData temporarily
+- Auto-deleted by backend, so iOS cache stays clean
+- No memory leak risk
+
+### Security Considerations
+
+**No vulnerabilities identified:**
+- Error messages don't expose internal paths or stack traces
+- Domain extraction uses `URI.parse` with rescue (safe)
+- User-scoped queries prevent cross-user data leaks (`current_user.recipes`)
+- No user input in error messages (domain comes from source_url)
+
+### Alternative Approaches Considered
+
+**Time-Based Auto-Delete (5 minutes)**
+- ❌ Less reliable - might delete before user sees it
+- ❌ Arbitrary timeout (5 min too long? too short?)
+- ❌ Doesn't adapt to user behavior
+
+**User-Dismissed Errors (Manual deletion)**
+- ❌ Adds friction - requires user action
+- ❌ More complex iOS UI (dismiss buttons)
+- ❌ Failed imports accumulate if ignored
+
+**Immediate Deletion (No user visibility)**
+- ❌ Mystery failures ("I tried importing but nothing happened")
+- ❌ No feedback loop for reporting issues
+
+## Dependencies & Risks
+
+### Dependencies
+
+**No external dependencies** - Uses existing gems and frameworks:
+- Rails 8.1 (already on project)
+- SQLite (already configured)
+- iOS 17+ SwiftUI (already minimum version)
+
+### Risks & Mitigation
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|-----------|
+| Users don't notice 1-minute banners | Low | Medium | Banners at top of list are prominent; 1 minute is reasonable viewing time |
+| Clock skew causes premature deletion | Low | Low | 1-minute buffer handles typical skew; server time is source of truth |
+| Too many concurrent failures clutter UI | Low | Medium | Stack banners vertically; ScrollView handles overflow gracefully |
+| Existing failed recipes cause confusion | Low | Low | Data migration deletes them before feature launch |
+| Backend deletion runs too frequently | Low | Low | Only runs on index action; WHERE clause is indexed |
+
+## Testing Strategy
+
+### Backend Tests
+
+**File**: `test/jobs/recipe_import_job_test.rb`
+
+```ruby
+test "stores error message on import failure" do
+  recipe = recipes(:pending_import)
+
+  # Mock failure
+  RecipeImporter.any_instance.stubs(:import).returns(
+    RecipeImportJob::Result.new(
+      success?: false,
+      error: "No recipe found",
+      error_code: :no_recipe_found
+    )
+  )
+
+  RecipeImportJob.perform_now(users(:one).id, recipe.id, "https://example.com/recipe")
+
+  recipe.reload
+  assert_equal "failed", recipe.import_status
+  assert_includes recipe.error_message, "example.com"
+  assert_includes recipe.error_message, "not supported"
+end
+
+test "handles text imports with appropriate error message" do
+  recipe = recipes(:pending_text_import)
+
+  RecipeTextExtractJob.expects(:perform_later)
+    .never  # Simulate immediate failure
+
+  # Perform job with text that can't be parsed
+  RecipeTextExtractJob.perform_now(users(:one).id, recipe.id, "random text")
+
+  recipe.reload
+  assert_equal "failed", recipe.import_status
+  assert_equal "Import failed - text doesn't contain a recipe", recipe.error_message
+end
+```
+
+**File**: `test/controllers/api/v1/recipes_controller_test.rb`
+
+```ruby
+test "tracks first fetch of failed recipes" do
+  recipe = recipes(:failed_import)
+  assert_nil recipe.failed_recipe_fetched_at
+
+  get api_v1_recipes_path, headers: authenticated_headers
+
+  recipe.reload
+  assert_not_nil recipe.failed_recipe_fetched_at
+  assert_in_delta Time.current, recipe.failed_recipe_fetched_at, 2.seconds
+end
+
+test "deletes failed recipes after 1 minute" do
+  recipe = recipes(:failed_import)
+  recipe.update!(failed_recipe_fetched_at: 2.minutes.ago)
+
+  assert_difference "Recipe.count", -1 do
+    get api_v1_recipes_path, headers: authenticated_headers
+  end
+
+  assert_raises(ActiveRecord::RecordNotFound) { recipe.reload }
+end
+
+test "does not delete recently fetched failed recipes" do
+  recipe = recipes(:failed_import)
+  recipe.update!(failed_recipe_fetched_at: 30.seconds.ago)
+
+  assert_no_difference "Recipe.count" do
+    get api_v1_recipes_path, headers: authenticated_headers
+  end
+
+  assert_nothing_raised { recipe.reload }
+end
+
+test "includes error_message in recipe list JSON" do
+  recipe = recipes(:failed_import)
+  recipe.update!(error_message: "Import from test.com failed")
+
+  get api_v1_recipes_path, headers: authenticated_headers
+
+  json = JSON.parse(response.body)
+  failed_recipe = json.find { |r| r["id"] == recipe.id }
+
+  assert_equal "Import from test.com failed", failed_recipe["error_message"]
+  assert_equal "failed", failed_recipe["import_status"]
+end
+```
+
+### iOS Tests
+
+**File**: `hauptgang-ios/HauptgangTests/ViewModels/RecipeViewModelTests.swift`
+
+```swift
+func testFailedRecipesFilteredCorrectly() {
+    // Create test recipes
+    let failed1 = PersistedRecipe(id: 1, name: "Test 1", favorite: false, updatedAt: Date())
+    failed1.importStatus = "failed"
+
+    let failed2 = PersistedRecipe(id: 2, name: "Test 2", favorite: false, updatedAt: Date())
+    failed2.importStatus = "failed"
+
+    let successful = PersistedRecipe(id: 3, name: "Test 3", favorite: false, updatedAt: Date())
+    successful.importStatus = "completed"
+
+    viewModel.recipes = [failed1, failed2, successful]
+
+    XCTAssertEqual(viewModel.failedRecipes.count, 2)
+    XCTAssertEqual(viewModel.successfulRecipes.count, 1)
+}
+
+func testPollingDoesNotTriggerForFailedRecipes() {
+    let failedRecipe = PersistedRecipe(id: 1, name: "Test", favorite: false, updatedAt: Date())
+    failedRecipe.importStatus = "failed"
+
+    viewModel.recipes = [failedRecipe]
+
+    XCTAssertFalse(viewModel.hasPendingImports)
+}
+```
+
+### Manual Testing Checklist
+
+- [ ] **Test 1**: Import from unsupported domain (example.com)
+  - Verify error banner appears
+  - Verify domain name shown in message
+  - Verify banner disappears after ~1 minute
+
+- [ ] **Test 2**: Import 3 recipes simultaneously, all fail
+  - Verify 3 stacked banners appear
+  - Verify UI scrolls correctly
+  - Verify all disappear after ~1 minute
+
+- [ ] **Test 3**: Rapid refreshing during banner display
+  - Pull to refresh 5 times in 10 seconds
+  - Verify banner doesn't disappear prematurely
+
+- [ ] **Test 4**: App backgrounding during banner display
+  - Trigger failed import
+  - Background app for 30 seconds
+  - Foreground app
+  - Verify banner still visible
+
+- [ ] **Test 5**: Multiple devices
+  - Device A: Trigger failed import
+  - Device A: See error banner
+  - Device B: Open app
+  - Device B: Should see error banner
+  - Wait 1 minute
+  - Both devices: Banner should disappear
+
+- [ ] **Test 6**: Text import failure
+  - Import from text: "random words no recipe"
+  - Verify message: "Import failed - text doesn't contain a recipe"
+
+## Implementation Checklist
+
+### Backend Tasks
+
+- [ ] Create migration: Add `error_message` and `failed_recipe_fetched_at` columns
+- [ ] Run migration: `bin/rails db:migrate`
+- [ ] Update `RecipeImportJob`: Add `build_error_message` and `extract_domain` methods
+- [ ] Update `RecipeImportJob`: Store error message on failure
+- [ ] Update `RecipeTextExtractJob`: Store error message on text import failure
+- [ ] Update `RecipesController#index`: Add `track_failed_recipe_fetches` call
+- [ ] Update `RecipesController`: Add `after_action :cleanup_old_failed_recipes`
+- [ ] Update `RecipesController#recipe_list_json`: Include `error_message` field
+- [ ] Create data migration: Clean up existing failed recipes
+- [ ] Write backend tests for error message storage
+- [ ] Write backend tests for fetch tracking
+- [ ] Write backend tests for cleanup timing
+- [ ] Run `bin/rubocop -a` to fix style issues
+- [ ] Run `bin/ci` to verify all checks pass
+
+### iOS Tasks
+
+- [ ] Update `Recipe.swift`: Add `errorMessage: String?` to `RecipeListItem`
+- [ ] Update `PersistedRecipe.swift`: Add `errorMessage` field
+- [ ] Update `PersistedRecipe.swift`: Update convenience initializers
+- [ ] Update `PersistedRecipe.swift`: Update `update(from:)` method
+- [ ] Create `ErrorBannerView.swift`: Implement banner component
+- [ ] Add SwiftUI previews to `ErrorBannerView.swift` (single + multiple errors)
+- [ ] Update `RecipesView.swift`: Add failed recipe banners to layout
+- [ ] Update `RecipeViewModel.swift`: Add `failedRecipes` computed property
+- [ ] Update `RecipeViewModel.swift`: Add `successfulRecipes` computed property
+- [ ] Update `RecipeCardView.swift`: Remove failed overlay case (optional cleanup)
+- [ ] Write iOS tests for recipe filtering
+- [ ] Write iOS tests for polling behavior with failed recipes
+- [ ] Run `bin/ios-test` to verify tests pass
+- [ ] Manual testing: Follow checklist above
+
+### Deployment Tasks
+
+- [ ] Merge to main branch
+- [ ] Deploy backend changes
+- [ ] Verify data migration ran successfully (check logs)
+- [ ] Submit iOS app update to App Store
+- [ ] Monitor for errors in production logs
+- [ ] Verify failed recipes are being cleaned up (check database)
+
+## Future Considerations
+
+### Potential Enhancements
+
+1. **Detailed Error Messages** (Low Priority)
+   - Map specific error codes to different messages
+   - Example: "Connection timeout - try again later" vs "Site doesn't support recipe imports"
+   - Trade-off: More complexity vs slightly more helpful
+
+2. **Fallback Cleanup** (Medium Priority)
+   - Add 7-day max age for failed recipes regardless of fetch status
+   - Handles edge case: user never opens app after import fails
+   - Implementation: Add WHERE clause `OR created_at < 7.days.ago`
+
+3. **Analytics** (Low Priority)
+   - Track which domains fail most often
+   - Helps prioritize adding support for popular sites
+   - Implementation: Log domain on failure with counter
+
+4. **User Reporting** (Low Priority)
+   - "Report this site" button on error banners
+   - Collects domains users want supported
+   - Implementation: New endpoint to store domain requests
+
+### Extensibility
+
+**If we add more import sources later** (PDF, email, etc.):
+- Error message pattern supports any source type
+- Domain extraction can be generalized to "source identifier"
+- Banner UI scales to different error types
+
+**If we add localization later:**
+- Error messages should move to i18n files
+- Domain name remains dynamic (not translated)
+- Example: `I18n.t('recipe_import.failed', domain: domain)`
+
+## References & Research
+
+### Internal References
+
+**Backend Files:**
+- `app/models/recipe.rb:3` - Enum definition
+- `app/jobs/recipe_import_job.rb:17` - Current failure handling
+- `app/controllers/api/v1/recipes_controller.rb:62-73` - List JSON response
+- `db/migrate/20260127105314_add_import_status_to_recipes.rb` - Migration pattern
+
+**iOS Files:**
+- `hauptgang-ios/Hauptgang/Models/Recipe.swift:13` - RecipeListItem structure
+- `hauptgang-ios/Hauptgang/Views/RecipesView.swift:54-60` - Error display pattern
+- `hauptgang-ios/Hauptgang/Views/RecipeCardView.swift:137-158` - Failed overlay pattern
+- `hauptgang-ios/Hauptgang/ViewModels/RecipeViewModel.swift:14` - Polling logic
+
+### Design Documents
+
+- [Brainstorm Document](../brainstorms/2026-01-30-failed-recipe-import-handling-brainstorm.md) - Full exploration of alternatives and decisions
+
+### Key Patterns Used
+
+- **Rails `after_action`**: Post-response cleanup without slowing down API
+- **SwiftUI `@Observable`**: Reactive state management with computed properties
+- **Time-based auto-delete**: Prevents race conditions from multiple devices
+- **Error banners at top**: More prominent than inline card overlays

--- a/docs/plans/2026-01-30-feat-failed-recipe-import-handling-plan.md
+++ b/docs/plans/2026-01-30-feat-failed-recipe-import-handling-plan.md
@@ -766,18 +766,18 @@ func testPollingDoesNotTriggerForFailedRecipes() {
 
 ### Backend Tasks
 
-- [ ] Create migration: Add `error_message` and `failed_recipe_fetched_at` columns
-- [ ] Run migration: `bin/rails db:migrate`
-- [ ] Update `RecipeImportJob`: Add `build_error_message` and `extract_domain` methods
-- [ ] Update `RecipeImportJob`: Store error message on failure
-- [ ] Update `RecipeTextExtractJob`: Store error message on text import failure
-- [ ] Update `RecipesController#index`: Add `track_failed_recipe_fetches` call
-- [ ] Update `RecipesController`: Add `after_action :cleanup_old_failed_recipes`
-- [ ] Update `RecipesController#recipe_list_json`: Include `error_message` field
+- [x] Create migration: Add `error_message` and `failed_recipe_fetched_at` columns
+- [x] Run migration: `bin/rails db:migrate`
+- [x] Update `RecipeImportJob`: Add `build_error_message` and `extract_domain` methods
+- [x] Update `RecipeImportJob`: Store error message on failure
+- [x] Update `RecipeTextExtractJob`: Store error message on text import failure
+- [x] Update `RecipesController#index`: Add `track_failed_recipe_fetches` call
+- [x] Update `RecipesController`: Add `after_action :cleanup_old_failed_recipes`
+- [x] Update `RecipesController#recipe_list_json`: Include `error_message` field
 - [ ] Create data migration: Clean up existing failed recipes
-- [ ] Write backend tests for error message storage
-- [ ] Write backend tests for fetch tracking
-- [ ] Write backend tests for cleanup timing
+- [x] Write backend tests for error message storage
+- [x] Write backend tests for fetch tracking
+- [x] Write backend tests for cleanup timing
 - [ ] Run `bin/rubocop -a` to fix style issues
 - [ ] Run `bin/ci` to verify all checks pass
 

--- a/hauptgang-ios/Hauptgang/Hauptgang.entitlements
+++ b/hauptgang-ios/Hauptgang/Hauptgang.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)app.hauptgang.shared</string>
+	</array>
+</dict>
+</plist>

--- a/hauptgang-ios/Hauptgang/Models/ImportRecipeResponse.swift
+++ b/hauptgang-ios/Hauptgang/Models/ImportRecipeResponse.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// Response from POST /api/v1/recipes/import
+struct ImportRecipeResponse: Codable, Sendable {
+    let id: Int
+    let importStatus: String
+}

--- a/hauptgang-ios/Hauptgang/Models/PersistedRecipe.swift
+++ b/hauptgang-ios/Hauptgang/Models/PersistedRecipe.swift
@@ -12,6 +12,7 @@ final class PersistedRecipe {
     var cookTime: Int?
     var favorite: Bool
     var coverImageUrl: String?
+    var importStatus: String?
     var updatedAt: Date
 
     /// Tracks when this record was last synced from the API
@@ -80,6 +81,7 @@ final class PersistedRecipe {
         cookTime: Int? = nil,
         favorite: Bool = false,
         coverImageUrl: String? = nil,
+        importStatus: String? = nil,
         updatedAt: Date,
         lastFetchedAt: Date = Date()
     ) {
@@ -89,6 +91,7 @@ final class PersistedRecipe {
         self.cookTime = cookTime
         self.favorite = favorite
         self.coverImageUrl = coverImageUrl
+        self.importStatus = importStatus
         self.updatedAt = updatedAt
         self.lastFetchedAt = lastFetchedAt
     }
@@ -102,6 +105,7 @@ final class PersistedRecipe {
             cookTime: listItem.cookTime,
             favorite: listItem.favorite,
             coverImageUrl: listItem.coverImageUrl,
+            importStatus: listItem.importStatus,
             updatedAt: listItem.updatedAt
         )
     }
@@ -129,6 +133,7 @@ final class PersistedRecipe {
         cookTime = listItem.cookTime
         favorite = listItem.favorite
         coverImageUrl = listItem.coverImageUrl
+        importStatus = listItem.importStatus
         updatedAt = listItem.updatedAt
         lastFetchedAt = Date()
     }

--- a/hauptgang-ios/Hauptgang/Models/PersistedRecipe.swift
+++ b/hauptgang-ios/Hauptgang/Models/PersistedRecipe.swift
@@ -13,6 +13,7 @@ final class PersistedRecipe {
     var favorite: Bool
     var coverImageUrl: String?
     var importStatus: String?
+    var errorMessage: String?
     var updatedAt: Date
 
     /// Tracks when this record was last synced from the API
@@ -82,6 +83,7 @@ final class PersistedRecipe {
         favorite: Bool = false,
         coverImageUrl: String? = nil,
         importStatus: String? = nil,
+        errorMessage: String? = nil,
         updatedAt: Date,
         lastFetchedAt: Date = Date()
     ) {
@@ -92,6 +94,7 @@ final class PersistedRecipe {
         self.favorite = favorite
         self.coverImageUrl = coverImageUrl
         self.importStatus = importStatus
+        self.errorMessage = errorMessage
         self.updatedAt = updatedAt
         self.lastFetchedAt = lastFetchedAt
     }
@@ -106,6 +109,7 @@ final class PersistedRecipe {
             favorite: listItem.favorite,
             coverImageUrl: listItem.coverImageUrl,
             importStatus: listItem.importStatus,
+            errorMessage: listItem.errorMessage,
             updatedAt: listItem.updatedAt
         )
     }
@@ -134,6 +138,7 @@ final class PersistedRecipe {
         favorite = listItem.favorite
         coverImageUrl = listItem.coverImageUrl
         importStatus = listItem.importStatus
+        errorMessage = listItem.errorMessage
         updatedAt = listItem.updatedAt
         lastFetchedAt = Date()
     }

--- a/hauptgang-ios/Hauptgang/Models/Recipe.swift
+++ b/hauptgang-ios/Hauptgang/Models/Recipe.swift
@@ -11,6 +11,7 @@ struct RecipeListItem: Codable, Identifiable, Sendable {
     let favorite: Bool
     let coverImageUrl: String?
     let importStatus: String?
+    let errorMessage: String?
     let updatedAt: Date
 }
 

--- a/hauptgang-ios/Hauptgang/Models/Recipe.swift
+++ b/hauptgang-ios/Hauptgang/Models/Recipe.swift
@@ -10,6 +10,7 @@ struct RecipeListItem: Codable, Identifiable, Sendable {
     let cookTime: Int?
     let favorite: Bool
     let coverImageUrl: String?
+    let importStatus: String?
     let updatedAt: Date
 }
 

--- a/hauptgang-ios/Hauptgang/Resources/Info.plist
+++ b/hauptgang-ios/Hauptgang/Resources/Info.plist
@@ -20,6 +20,19 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>app.hauptgang.ios</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>hauptgang</string>
+			</array>
+		</dict>
+	</array>
+	<key>KeychainAccessGroup</key>
+	<string>$(AppIdentifierPrefix)app.hauptgang.shared</string>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/hauptgang-ios/Hauptgang/Services/RecipeImportService.swift
+++ b/hauptgang-ios/Hauptgang/Services/RecipeImportService.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Service for importing recipes from URLs
+actor RecipeImportService {
+    static let shared = RecipeImportService()
+
+    private init() {}
+
+    /// Import a recipe from a URL (fire-and-forget)
+    /// The server creates a pending recipe and processes it asynchronously
+    func importRecipe(from url: URL) async throws -> ImportRecipeResponse {
+        struct ImportRequest: Encodable {
+            let url: String
+        }
+
+        return try await APIClient.shared.request(
+            endpoint: "recipes/import",
+            method: .post,
+            body: ImportRequest(url: url.absoluteString),
+            authenticated: true
+        )
+    }
+}

--- a/hauptgang-ios/Hauptgang/Services/RecipeRepository.swift
+++ b/hauptgang-ios/Hauptgang/Services/RecipeRepository.swift
@@ -66,7 +66,7 @@ final class RecipeRepository: RecipeRepositoryProtocol {
         logger.info("Successfully saved \(recipes.count) recipes")
     }
 
-    /// Retrieve all cached recipes, sorted by name
+    /// Retrieve all cached recipes, sorted by most recent update
     func getAllRecipes() throws -> [PersistedRecipe] {
         guard let modelContext else {
             logger.error("Attempted to fetch recipes without model context")
@@ -74,7 +74,7 @@ final class RecipeRepository: RecipeRepositoryProtocol {
         }
 
         let descriptor = FetchDescriptor<PersistedRecipe>(
-            sortBy: [SortDescriptor(\.name)]
+            sortBy: [SortDescriptor(\.updatedAt, order: .reverse)]
         )
 
         let recipes = try modelContext.fetch(descriptor)

--- a/hauptgang-ios/Hauptgang/Services/RecipeRepository.swift
+++ b/hauptgang-ios/Hauptgang/Services/RecipeRepository.swift
@@ -23,6 +23,7 @@ protocol RecipeRepositoryProtocol {
     func clearAllRecipes() throws
     func getRecipe(id: Int) throws -> PersistedRecipe?
     func saveRecipeDetail(_ detail: RecipeDetail) throws
+    func deleteRecipe(id: Int) throws
 }
 
 /// Handles local persistence of recipes using SwiftData
@@ -37,33 +38,41 @@ final class RecipeRepository: RecipeRepositoryProtocol {
         logger.info("RecipeRepository configured with model context")
     }
 
-    /// Save recipes from API response, updating existing or inserting new
+    /// Save recipes from API response, updating existing or inserting new, and removing stale entries
     func saveRecipes(_ recipes: [RecipeListItem]) throws {
         guard let modelContext else {
             logger.error("Attempted to save recipes without model context")
             throw RepositoryError.notConfigured
         }
 
-        logger.info("Saving \(recipes.count) recipes to local storage")
+        logger.info("Syncing \(recipes.count) recipes to local storage")
 
+        let apiRecipeIds = Set(recipes.map { $0.id })
+
+        // Remove recipes that are no longer in the API response
+        let allLocalDescriptor = FetchDescriptor<PersistedRecipe>()
+        let allLocal = try modelContext.fetch(allLocalDescriptor)
+        for localRecipe in allLocal where !apiRecipeIds.contains(localRecipe.id) {
+            logger.info("Removing stale recipe: \(localRecipe.id)")
+            modelContext.delete(localRecipe)
+        }
+
+        // Add or update recipes from API
         for apiRecipe in recipes {
-            // Check if recipe already exists
             let descriptor = FetchDescriptor<PersistedRecipe>(
                 predicate: #Predicate { $0.id == apiRecipe.id }
             )
 
             if let existing = try modelContext.fetch(descriptor).first {
-                // Update existing recipe
                 existing.update(from: apiRecipe)
             } else {
-                // Insert new recipe
                 let newRecipe = PersistedRecipe(from: apiRecipe)
                 modelContext.insert(newRecipe)
             }
         }
 
         try modelContext.save()
-        logger.info("Successfully saved \(recipes.count) recipes")
+        logger.info("Successfully synced \(recipes.count) recipes")
     }
 
     /// Retrieve all cached recipes, sorted by most recent update
@@ -138,5 +147,25 @@ final class RecipeRepository: RecipeRepositoryProtocol {
 
         try modelContext.save()
         logger.info("Successfully saved recipe detail for: \(detail.name)")
+    }
+
+    /// Delete a recipe by ID from local cache
+    func deleteRecipe(id: Int) throws {
+        guard let modelContext else {
+            logger.error("Attempted to delete recipe without model context")
+            throw RepositoryError.notConfigured
+        }
+
+        logger.info("Deleting recipe with id: \(id)")
+
+        let descriptor = FetchDescriptor<PersistedRecipe>(
+            predicate: #Predicate { $0.id == id }
+        )
+
+        if let recipe = try modelContext.fetch(descriptor).first {
+            modelContext.delete(recipe)
+            try modelContext.save()
+            logger.info("Deleted recipe with id: \(id)")
+        }
     }
 }

--- a/hauptgang-ios/Hauptgang/Services/RecipeService.swift
+++ b/hauptgang-ios/Hauptgang/Services/RecipeService.swift
@@ -5,6 +5,7 @@ import os
 protocol RecipeServiceProtocol: Sendable {
     func fetchRecipes() async throws -> [RecipeListItem]
     func fetchRecipeDetail(id: Int) async throws -> RecipeDetail
+    func deleteRecipe(id: Int) async throws
 }
 
 /// Handles all recipe-related API calls
@@ -42,5 +43,21 @@ final class RecipeService: RecipeServiceProtocol, @unchecked Sendable {
 
         logger.info("Fetched recipe detail: \(recipe.name)")
         return recipe
+    }
+
+    /// Deletes a recipe by ID
+    func deleteRecipe(id: Int) async throws {
+        logger.info("Deleting recipe with id: \(id)")
+
+        do {
+            try await api.requestVoid(
+                endpoint: "recipes/\(id)",
+                method: .delete,
+                authenticated: true
+            )
+            logger.info("Deleted recipe with id: \(id)")
+        } catch APIError.notFound {
+            logger.info("Recipe \(id) already deleted on server")
+        }
     }
 }

--- a/hauptgang-ios/Hauptgang/Utilities/Color+Theme.swift
+++ b/hauptgang-ios/Hauptgang/Utilities/Color+Theme.swift
@@ -41,6 +41,9 @@ extension Color {
     /// Error red - #DC2626
     static let hauptgangError = Color(red: 220/255, green: 38/255, blue: 38/255)
 
+    /// Soft error red - #EF4444 (for banners/toasts)
+    static let hauptgangErrorSoft = Color(red: 239/255, green: 68/255, blue: 68/255)
+
     /// Success green - #16A34A
     static let hauptgangSuccess = Color(red: 22/255, green: 163/255, blue: 74/255)
 

--- a/hauptgang-ios/Hauptgang/Utilities/Constants.swift
+++ b/hauptgang-ios/Hauptgang/Utilities/Constants.swift
@@ -5,13 +5,24 @@ enum Constants {
         #if DEBUG
         // Local development - use your Mac's IP for device testing
         // For simulator: localhost works fine
+        static let host = URL(string: "http://127.0.0.1:3000")!
         static let baseURL = URL(string: "http://127.0.0.1:3000/api/v1")!
         #else
         // Production URL - update when deploying
+        static let host = URL(string: "https://hauptgang.example.com")!
         static let baseURL = URL(string: "https://hauptgang.example.com/api/v1")!
         #endif
 
         static let sessionPath = "/session"
+
+        /// Resolves a relative path (e.g., "/rails/active_storage/...") to a full URL
+        static func resolveURL(_ path: String?) -> URL? {
+            guard let path, !path.isEmpty else { return nil }
+            if path.hasPrefix("http://") || path.hasPrefix("https://") {
+                return URL(string: path)
+            }
+            return URL(string: path, relativeTo: host)
+        }
     }
 
     enum Keychain {

--- a/hauptgang-ios/Hauptgang/Utilities/Constants.swift
+++ b/hauptgang-ios/Hauptgang/Utilities/Constants.swift
@@ -19,5 +19,11 @@ enum Constants {
         static let tokenKey = "auth_token"
         static let tokenExpiryKey = "auth_token_expiry"
         static let userKey = "current_user"
+        /// Shared access group for Keychain sharing between app and extensions.
+        /// Read from Info.plist where $(AppIdentifierPrefix) is expanded at build time.
+        /// Returns nil if not configured, which uses the app's default access group.
+        static var accessGroup: String? {
+            Bundle.main.object(forInfoDictionaryKey: "KeychainAccessGroup") as? String
+        }
     }
 }

--- a/hauptgang-ios/Hauptgang/Views/ErrorBannerView.swift
+++ b/hauptgang-ios/Hauptgang/Views/ErrorBannerView.swift
@@ -1,0 +1,166 @@
+import SwiftData
+import SwiftUI
+
+struct ErrorBannerView: View {
+    let recipe: PersistedRecipe
+    let onDismiss: () -> Void
+
+    @State private var offset: CGFloat = 0
+    @State private var isDismissing = false
+
+    /// Swipe distance required to trigger dismiss
+    private let dismissThreshold: CGFloat = 80
+
+    /// Auto-dismiss delay in seconds
+    private let autoDismissDelay: Double = 5.0
+
+    /// Vertical offset for dismiss animation
+    @State private var verticalOffset: CGFloat = 0
+
+    var body: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            // Error icon
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.title3)
+                .foregroundColor(.white)
+                .frame(width: 24)
+
+            // Error message text
+            VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                if let errorMessage = recipe.errorMessage {
+                    Text(errorMessage)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+                        .multilineTextAlignment(.leading)
+                } else {
+                    // Fallback for recipes without error_message
+                    Text("Import failed - page is not supported")
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+                }
+            }
+
+            Spacer()
+        }
+        .padding(Theme.Spacing.md)
+        .background(
+            RoundedRectangle(cornerRadius: Theme.CornerRadius.lg)
+                .fill(Color.hauptgangErrorSoft)
+        )
+        .shadow(
+            color: Color.black.opacity(0.1),
+            radius: 4,
+            x: 0,
+            y: 2
+        )
+        .offset(x: offset, y: verticalOffset)
+        .opacity(dismissOpacity)
+        .gesture(
+            DragGesture()
+                .onChanged { value in
+                    offset = value.translation.width
+                }
+                .onEnded { value in
+                    let swipeDistance = abs(value.translation.width)
+                    if swipeDistance > dismissThreshold {
+                        dismiss(direction: value.translation.width > 0 ? 1 : -1)
+                    } else {
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                            offset = 0
+                        }
+                    }
+                }
+        )
+        .task {
+            try? await Task.sleep(for: .seconds(autoDismissDelay))
+            if !isDismissing {
+                autoDismiss()
+            }
+        }
+    }
+
+    /// Opacity decreases as user swipes further or during dismiss
+    private var dismissOpacity: Double {
+        // During vertical dismiss animation
+        if verticalOffset > 0 {
+            return max(0, 1 - verticalOffset / 40)
+        }
+        // During horizontal swipe
+        let progress = abs(offset) / dismissThreshold
+        return max(0.3, 1 - progress * 0.5)
+    }
+
+    /// Animate off screen horizontally (swipe dismiss)
+    private func dismiss(direction: CGFloat) {
+        guard !isDismissing else { return }
+        isDismissing = true
+
+        withAnimation(.easeOut(duration: 0.2)) {
+            offset = direction * 400
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            onDismiss()
+        }
+    }
+
+    /// Animate down gently (auto dismiss)
+    private func autoDismiss() {
+        guard !isDismissing else { return }
+        isDismissing = true
+
+        withAnimation(.easeInOut(duration: 0.3)) {
+            verticalOffset = 100
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+            onDismiss()
+        }
+    }
+}
+
+// MARK: - Preview
+#Preview("Single Error") {
+    ErrorBannerView(
+        recipe: {
+            let recipe = PersistedRecipe(
+                id: 1,
+                name: "Importing...",
+                favorite: false,
+                updatedAt: Date()
+            )
+            recipe.importStatus = "failed"
+            recipe.errorMessage = "Import from allrecipes.com failed - page is not supported or doesn't contain a recipe"
+            return recipe
+        }(),
+        onDismiss: {}
+    )
+    .padding()
+}
+
+#Preview("Multiple Errors") {
+    VStack(spacing: Theme.Spacing.sm) {
+        ErrorBannerView(
+            recipe: {
+                let recipe = PersistedRecipe(id: 1, name: "Test", favorite: false, updatedAt: Date())
+                recipe.importStatus = "failed"
+                recipe.errorMessage = "Import from allrecipes.com failed - page is not supported or doesn't contain a recipe"
+                return recipe
+            }(),
+            onDismiss: {}
+        )
+
+        ErrorBannerView(
+            recipe: {
+                let recipe = PersistedRecipe(id: 2, name: "Test", favorite: false, updatedAt: Date())
+                recipe.importStatus = "failed"
+                recipe.errorMessage = "Import from epicurious.com failed - page is not supported or doesn't contain a recipe"
+                return recipe
+            }(),
+            onDismiss: {}
+        )
+    }
+    .padding()
+}

--- a/hauptgang-ios/Hauptgang/Views/RecipeCardView.swift
+++ b/hauptgang-ios/Hauptgang/Views/RecipeCardView.swift
@@ -19,6 +19,11 @@ struct RecipeCardView: View {
 
             // Content overlay
             contentView
+
+            // Import status overlay
+            if let status = recipe.importStatus {
+                importStatusOverlay(status: status)
+            }
         }
         .frame(height: cardHeight)
         .clipShape(RoundedRectangle(cornerRadius: Theme.CornerRadius.lg))
@@ -40,11 +45,7 @@ struct RecipeCardView: View {
                 AsyncImage(url: url) { phase in
                     switch phase {
                     case .empty:
-                        Color.gray.opacity(0.2)
-                            .overlay {
-                                ProgressView()
-                                    .tint(.hauptgangTextMuted)
-                            }
+                        Color.hauptgangSurfaceRaised
                     case .success(let image):
                         image
                             .resizable()
@@ -111,6 +112,56 @@ struct RecipeCardView: View {
         .padding(Theme.Spacing.md)
     }
 
+    // MARK: - Import Status Overlay
+
+    @ViewBuilder
+    private func importStatusOverlay(status: String) -> some View {
+        switch status {
+        case "pending":
+            ZStack {
+                // Semi-transparent overlay
+                Color.black.opacity(0.5)
+
+                VStack(spacing: Theme.Spacing.sm) {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                        .scaleEffect(1.2)
+
+                    Text("Importing...")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundColor(.white)
+                }
+            }
+
+        case "failed":
+            ZStack {
+                // Semi-transparent red overlay
+                Color.hauptgangError.opacity(0.8)
+
+                VStack(spacing: Theme.Spacing.sm) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .font(.title2)
+                        .foregroundColor(.white)
+
+                    Text("Import failed")
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.white)
+
+                    Text("We couldn't find a recipe on this page, or this website isn't supported yet.")
+                        .font(.caption)
+                        .foregroundColor(.white.opacity(0.9))
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, Theme.Spacing.md)
+                }
+            }
+
+        default:
+            EmptyView()
+        }
+    }
+
     // MARK: - Helpers
 
     private var hasImage: Bool {
@@ -123,6 +174,16 @@ struct RecipeCardView: View {
         let cook = recipe.cookTime ?? 0
         let total = prep + cook
         return total > 0 ? total : nil
+    }
+
+    /// Whether the recipe is currently being imported
+    var isPending: Bool {
+        recipe.importStatus == "pending"
+    }
+
+    /// Whether the recipe import failed
+    var isFailed: Bool {
+        recipe.importStatus == "failed"
     }
 }
 

--- a/hauptgang-ios/Hauptgang/Views/RecipeCardView.swift
+++ b/hauptgang-ios/Hauptgang/Views/RecipeCardView.swift
@@ -11,7 +11,7 @@ struct RecipeCardView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             // Background layer
-            if let imageUrl = recipe.coverImageUrl, let url = URL(string: imageUrl) {
+            if let url = Constants.API.resolveURL(recipe.coverImageUrl) {
                 imageBackgroundView(url: url)
             } else {
                 solidBackgroundView
@@ -134,29 +134,6 @@ struct RecipeCardView: View {
                 }
             }
 
-        case "failed":
-            ZStack {
-                // Semi-transparent red overlay
-                Color.hauptgangError.opacity(0.8)
-
-                VStack(spacing: Theme.Spacing.sm) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .font(.title2)
-                        .foregroundColor(.white)
-
-                    Text("Import failed")
-                        .font(.subheadline)
-                        .fontWeight(.semibold)
-                        .foregroundColor(.white)
-
-                    Text("We couldn't find a recipe on this page, or this website isn't supported yet.")
-                        .font(.caption)
-                        .foregroundColor(.white.opacity(0.9))
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, Theme.Spacing.md)
-                }
-            }
-
         default:
             EmptyView()
         }
@@ -179,11 +156,6 @@ struct RecipeCardView: View {
     /// Whether the recipe is currently being imported
     var isPending: Bool {
         recipe.importStatus == "pending"
-    }
-
-    /// Whether the recipe import failed
-    var isFailed: Bool {
-        recipe.importStatus == "failed"
     }
 }
 

--- a/hauptgang-ios/Hauptgang/Views/RecipeDetailView.swift
+++ b/hauptgang-ios/Hauptgang/Views/RecipeDetailView.swift
@@ -145,7 +145,7 @@ struct RecipeDetailView: View {
 
     @ViewBuilder
     private func heroImage(_ recipe: RecipeDetail) -> some View {
-        if let imageUrl = recipe.coverImageUrl, let url = URL(string: imageUrl) {
+        if let url = Constants.API.resolveURL(recipe.coverImageUrl) {
             AsyncImage(url: url) { phase in
                 switch phase {
                 case .empty:

--- a/hauptgang-ios/HauptgangTests/Mocks/MockRecipeRepository.swift
+++ b/hauptgang-ios/HauptgangTests/Mocks/MockRecipeRepository.swift
@@ -51,4 +51,8 @@ final class MockRecipeRepository: RecipeRepositoryProtocol {
         }
         savedRecipeDetail = detail
     }
+
+    func deleteRecipe(id: Int) throws {
+        allRecipes.removeAll { $0.id == id }
+    }
 }

--- a/hauptgang-ios/HauptgangTests/Mocks/MockRecipeService.swift
+++ b/hauptgang-ios/HauptgangTests/Mocks/MockRecipeService.swift
@@ -3,6 +3,8 @@ import Foundation
 
 final class MockRecipeService: RecipeServiceProtocol, @unchecked Sendable {
     var fetchRecipesResult: Result<[RecipeListItem], Error> = .success([])
+    var fetchRecipesCalled = false
+    var fetchRecipesCallCount = 0
     var fetchRecipeDetailResult: Result<RecipeDetail, Error> = .success(
         RecipeDetail.mock()
     )
@@ -10,13 +12,25 @@ final class MockRecipeService: RecipeServiceProtocol, @unchecked Sendable {
     var fetchRecipeDetailCalledWithId: Int?
 
     func fetchRecipes() async throws -> [RecipeListItem] {
-        try fetchRecipesResult.get()
+        fetchRecipesCalled = true
+        fetchRecipesCallCount += 1
+        return try fetchRecipesResult.get()
     }
 
     func fetchRecipeDetail(id: Int) async throws -> RecipeDetail {
         fetchRecipeDetailCalled = true
         fetchRecipeDetailCalledWithId = id
         return try fetchRecipeDetailResult.get()
+    }
+
+    var deleteRecipeCalled = false
+    var deleteRecipeCalledWithId: Int?
+    var deleteRecipeResult: Result<Void, Error> = .success(())
+
+    func deleteRecipe(id: Int) async throws {
+        deleteRecipeCalled = true
+        deleteRecipeCalledWithId = id
+        try deleteRecipeResult.get()
     }
 }
 
@@ -43,6 +57,7 @@ extension RecipeListItem {
         favorite: Bool = false,
         coverImageUrl: String? = nil,
         importStatus: String? = nil,
+        errorMessage: String? = nil,
         updatedAt: Date = Date()
     ) -> RecipeListItem {
         RecipeListItem(
@@ -53,6 +68,7 @@ extension RecipeListItem {
             favorite: favorite,
             coverImageUrl: coverImageUrl,
             importStatus: importStatus,
+            errorMessage: errorMessage,
             updatedAt: updatedAt
         )
     }

--- a/hauptgang-ios/HauptgangTests/Mocks/MockRecipeService.swift
+++ b/hauptgang-ios/HauptgangTests/Mocks/MockRecipeService.swift
@@ -34,6 +34,30 @@ enum MockRecipeError: Error, LocalizedError {
     }
 }
 
+extension RecipeListItem {
+    static func mock(
+        id: Int = 1,
+        name: String = "Test Recipe",
+        prepTime: Int? = 15,
+        cookTime: Int? = 30,
+        favorite: Bool = false,
+        coverImageUrl: String? = nil,
+        importStatus: String? = nil,
+        updatedAt: Date = Date()
+    ) -> RecipeListItem {
+        RecipeListItem(
+            id: id,
+            name: name,
+            prepTime: prepTime,
+            cookTime: cookTime,
+            favorite: favorite,
+            coverImageUrl: coverImageUrl,
+            importStatus: importStatus,
+            updatedAt: updatedAt
+        )
+    }
+}
+
 extension RecipeDetail {
     static func mock(
         id: Int = 1,

--- a/hauptgang-ios/HauptgangTests/Utilities/ConstantsTests.swift
+++ b/hauptgang-ios/HauptgangTests/Utilities/ConstantsTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import Hauptgang
+
+final class ConstantsTests: XCTestCase {
+    // MARK: - resolveURL Tests
+
+    func testResolveURL_withNil_returnsNil() {
+        XCTAssertNil(Constants.API.resolveURL(nil))
+    }
+
+    func testResolveURL_withEmptyString_returnsNil() {
+        XCTAssertNil(Constants.API.resolveURL(""))
+    }
+
+    func testResolveURL_withRelativePath_resolvesAgainstHost() {
+        let result = Constants.API.resolveURL("/rails/active_storage/blobs/123")
+
+        XCTAssertNotNil(result)
+        XCTAssertTrue(result!.absoluteString.contains("127.0.0.1:3000"))
+        XCTAssertTrue(result!.absoluteString.contains("/rails/active_storage/blobs/123"))
+    }
+
+    func testResolveURL_withAbsoluteHttpUrl_returnsAsIs() {
+        let absoluteUrl = "http://example.com/image.jpg"
+        let result = Constants.API.resolveURL(absoluteUrl)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.absoluteString, absoluteUrl)
+    }
+
+    func testResolveURL_withAbsoluteHttpsUrl_returnsAsIs() {
+        let absoluteUrl = "https://example.com/image.jpg"
+        let result = Constants.API.resolveURL(absoluteUrl)
+
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result!.absoluteString, absoluteUrl)
+    }
+}

--- a/hauptgang-ios/HauptgangTests/ViewModels/RecipeDetailViewModelTests.swift
+++ b/hauptgang-ios/HauptgangTests/ViewModels/RecipeDetailViewModelTests.swift
@@ -191,17 +191,7 @@ final class RecipeDetailViewModelTests: XCTestCase {
     // MARK: - Helpers
 
     private func createMockPersistedRecipe(id: Int, name: String) -> PersistedRecipe {
-        let recipe = PersistedRecipe(
-            from: RecipeListItem(
-                id: id,
-                name: name,
-                prepTime: nil,
-                cookTime: nil,
-                favorite: false,
-                coverImageUrl: nil,
-                updatedAt: Date()
-            )
-        )
+        let recipe = PersistedRecipe(from: RecipeListItem.mock(id: id, name: name))
         recipe.detailLastFetchedAt = Date()
         recipe.ingredientsJson = "[\"Ingredient 1\"]"
         recipe.instructionsJson = "[\"Step 1\"]"

--- a/hauptgang-ios/HauptgangTests/ViewModels/RecipeViewModelTests.swift
+++ b/hauptgang-ios/HauptgangTests/ViewModels/RecipeViewModelTests.swift
@@ -1,0 +1,191 @@
+import SwiftData
+import XCTest
+@testable import Hauptgang
+
+@MainActor
+final class RecipeViewModelTests: XCTestCase {
+    private var sut: RecipeViewModel!
+    private var mockRecipeService: MockRecipeService!
+    private var mockRepository: MockRecipeRepository!
+
+    override func setUp() {
+        super.setUp()
+        mockRecipeService = MockRecipeService()
+        mockRepository = MockRecipeRepository()
+        sut = RecipeViewModel(
+            recipeService: mockRecipeService,
+            repository: mockRepository
+        )
+    }
+
+    override func tearDown() {
+        sut.stopPolling()
+        sut = nil
+        mockRecipeService = nil
+        mockRepository = nil
+        super.tearDown()
+    }
+
+    // MARK: - hasPendingImports Tests
+
+    func testHasPendingImports_withPendingRecipe_returnsTrue() {
+        let pendingRecipe = createMockPersistedRecipe(id: 1, name: "Pending", importStatus: "pending")
+        mockRepository.allRecipes = [pendingRecipe]
+
+        // Simulate configure() which loads cached recipes
+        loadCachedRecipesIntoViewModel()
+
+        XCTAssertTrue(sut.hasPendingImports)
+    }
+
+    func testHasPendingImports_withCompletedRecipes_returnsFalse() {
+        let completedRecipe = createMockPersistedRecipe(id: 1, name: "Completed", importStatus: "completed")
+        let noStatusRecipe = createMockPersistedRecipe(id: 2, name: "No Status", importStatus: nil)
+        mockRepository.allRecipes = [completedRecipe, noStatusRecipe]
+
+        loadCachedRecipesIntoViewModel()
+
+        XCTAssertFalse(sut.hasPendingImports)
+    }
+
+    func testHasPendingImports_withFailedRecipe_returnsFalse() {
+        let failedRecipe = createMockPersistedRecipe(id: 1, name: "Failed", importStatus: "failed")
+        mockRepository.allRecipes = [failedRecipe]
+
+        loadCachedRecipesIntoViewModel()
+
+        XCTAssertFalse(sut.hasPendingImports)
+    }
+
+    func testHasPendingImports_withEmptyRecipes_returnsFalse() {
+        mockRepository.allRecipes = []
+
+        loadCachedRecipesIntoViewModel()
+
+        XCTAssertFalse(sut.hasPendingImports)
+    }
+
+    func testHasPendingImports_withMixedStatuses_returnsTrue() {
+        let pendingRecipe = createMockPersistedRecipe(id: 1, name: "Pending", importStatus: "pending")
+        let completedRecipe = createMockPersistedRecipe(id: 2, name: "Completed", importStatus: "completed")
+        let failedRecipe = createMockPersistedRecipe(id: 3, name: "Failed", importStatus: "failed")
+        mockRepository.allRecipes = [pendingRecipe, completedRecipe, failedRecipe]
+
+        loadCachedRecipesIntoViewModel()
+
+        XCTAssertTrue(sut.hasPendingImports)
+    }
+
+    // MARK: - refreshRecipes Tests
+
+    func testRefreshRecipes_success_updatesRecipes() async {
+        let apiRecipes = [
+            RecipeListItem.mock(id: 1, name: "Recipe 1"),
+            RecipeListItem.mock(id: 2, name: "Recipe 2")
+        ]
+        mockRecipeService.fetchRecipesResult = .success(apiRecipes)
+
+        // Set up repository to return persisted versions after save
+        let persistedRecipes = apiRecipes.map { createMockPersistedRecipe(from: $0) }
+        mockRepository.allRecipes = persistedRecipes
+
+        await sut.refreshRecipes()
+
+        XCTAssertEqual(sut.recipes.count, 2)
+        XCTAssertNil(sut.errorMessage)
+        XCTAssertFalse(sut.isLoading)
+    }
+
+    func testRefreshRecipes_failure_setsErrorMessage() async {
+        mockRecipeService.fetchRecipesResult = .failure(MockRecipeError.networkError)
+
+        await sut.refreshRecipes()
+
+        XCTAssertNotNil(sut.errorMessage)
+        XCTAssertEqual(sut.errorMessage, "Failed to load recipes. Pull to retry.")
+        XCTAssertFalse(sut.isLoading)
+    }
+
+    func testRefreshRecipes_failure_keepsCachedData() async {
+        let cachedRecipe = createMockPersistedRecipe(id: 1, name: "Cached Recipe")
+        mockRepository.allRecipes = [cachedRecipe]
+        loadCachedRecipesIntoViewModel()
+
+        mockRecipeService.fetchRecipesResult = .failure(MockRecipeError.networkError)
+
+        await sut.refreshRecipes()
+
+        XCTAssertEqual(sut.recipes.count, 1)
+        XCTAssertEqual(sut.recipes.first?.name, "Cached Recipe")
+    }
+
+    func testRefreshRecipes_savesRecipesToRepository() async {
+        let apiRecipes = [RecipeListItem.mock(id: 1, name: "New Recipe")]
+        mockRecipeService.fetchRecipesResult = .success(apiRecipes)
+
+        await sut.refreshRecipes()
+
+        XCTAssertEqual(mockRepository.savedRecipes.count, 1)
+        XCTAssertEqual(mockRepository.savedRecipes.first?.name, "New Recipe")
+    }
+
+    func testRefreshRecipes_clearsErrorOnSuccess() async {
+        // First, create an error state
+        mockRecipeService.fetchRecipesResult = .failure(MockRecipeError.networkError)
+        await sut.refreshRecipes()
+        XCTAssertNotNil(sut.errorMessage)
+
+        // Then, refresh successfully
+        mockRecipeService.fetchRecipesResult = .success([RecipeListItem.mock()])
+        await sut.refreshRecipes()
+
+        XCTAssertNil(sut.errorMessage)
+    }
+
+    // MARK: - stopPolling Tests
+
+    func testStopPolling_whenNoActivePolling_doesNotCrash() {
+        sut.stopPolling()
+        // Test passes if no exception is thrown
+    }
+
+    func testStopPolling_calledMultipleTimes_doesNotCrash() {
+        sut.stopPolling()
+        sut.stopPolling()
+        sut.stopPolling()
+        // Test passes if no exception is thrown
+    }
+
+    // MARK: - clearData Tests
+
+    func testClearData_clearsRecipes() {
+        let recipe = createMockPersistedRecipe(id: 1, name: "Recipe")
+        mockRepository.allRecipes = [recipe]
+        loadCachedRecipesIntoViewModel()
+        XCTAssertEqual(sut.recipes.count, 1)
+
+        sut.clearData()
+
+        XCTAssertEqual(sut.recipes.count, 0)
+    }
+
+    // MARK: - Helpers
+
+    private func loadCachedRecipesIntoViewModel() {
+        let config = ModelConfiguration(isStoredInMemoryOnly: true)
+        let container = try! ModelContainer(for: PersistedRecipe.self, configurations: config)
+        sut.configure(modelContext: ModelContext(container))
+    }
+
+    private func createMockPersistedRecipe(
+        id: Int,
+        name: String,
+        importStatus: String? = nil
+    ) -> PersistedRecipe {
+        PersistedRecipe(from: RecipeListItem.mock(id: id, name: name, importStatus: importStatus))
+    }
+
+    private func createMockPersistedRecipe(from listItem: RecipeListItem) -> PersistedRecipe {
+        PersistedRecipe(from: listItem)
+    }
+}

--- a/hauptgang-ios/ImportRecipeExtension/ImportRecipeExtension.entitlements
+++ b/hauptgang-ios/ImportRecipeExtension/ImportRecipeExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)app.hauptgang.shared</string>
+	</array>
+</dict>
+</plist>

--- a/hauptgang-ios/ImportRecipeExtension/ImportRecipeView.swift
+++ b/hauptgang-ios/ImportRecipeExtension/ImportRecipeView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+enum ImportState {
+    case extracting
+    case importing(URL)
+    case success
+    case failed(String)
+    case notAuthenticated
+}
+
+struct ImportRecipeView: View {
+    let state: ImportState
+    let onClose: () -> Void
+    var onOpenApp: (() -> Void)?
+
+    var body: some View {
+        VStack(spacing: 24) {
+            switch state {
+            case .extracting:
+                extractingView
+            case .importing(let url):
+                importingView(url: url)
+            case .success:
+                successView
+            case .failed(let message):
+                failedView(message: message)
+            case .notAuthenticated:
+                notAuthenticatedView
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(24)
+        .background(Color(.systemBackground))
+    }
+
+    private var extractingView: some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.5)
+            Text("Extracting URL...")
+                .font(.headline)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func importingView(url: URL) -> some View {
+        VStack(spacing: 16) {
+            ProgressView()
+                .scaleEffect(1.5)
+            Text("Importing Recipe")
+                .font(.headline)
+            Text(url.host ?? url.absoluteString)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    private var successView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundColor(.green)
+            Text("Import Started!")
+                .font(.headline)
+            Text("Open Hauptgang to see your recipe.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private func failedView(message: String) -> some View {
+        VStack(spacing: 16) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 48))
+                .foregroundColor(.red)
+            Text("Import Failed")
+                .font(.headline)
+            Text(message)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Close", action: onClose)
+                .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var notAuthenticatedView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "person.crop.circle.badge.exclamationmark")
+                .font(.system(size: 48))
+                .foregroundColor(.orange)
+            Text("Not Signed In")
+                .font(.headline)
+            Text("Please open Hauptgang and sign in first.")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            HStack(spacing: 12) {
+                Button("Close", action: onClose)
+                    .buttonStyle(.bordered)
+                if let onOpenApp {
+                    Button("Open App", action: onOpenApp)
+                        .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+    }
+}
+
+#Preview("Extracting") {
+    ImportRecipeView(state: .extracting, onClose: {})
+}
+
+#Preview("Importing") {
+    ImportRecipeView(
+        state: .importing(URL(string: "https://example.com/recipe")!),
+        onClose: {}
+    )
+}
+
+#Preview("Success") {
+    ImportRecipeView(state: .success, onClose: {})
+}
+
+#Preview("Failed") {
+    ImportRecipeView(
+        state: .failed("Could not parse recipe from this URL"),
+        onClose: {}
+    )
+}
+
+#Preview("Not Authenticated") {
+    ImportRecipeView(state: .notAuthenticated, onClose: {})
+}

--- a/hauptgang-ios/ImportRecipeExtension/Info.plist
+++ b/hauptgang-ios/ImportRecipeExtension/Info.plist
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Import to Hauptgang</string>
+	<key>CFBundleName</key>
+	<string>ImportRecipeExtension</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<dict>
+				<key>NSExtensionActivationSupportsWebURLWithMaxCount</key>
+				<integer>1</integer>
+			</dict>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShareViewController</string>
+	</dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>KeychainAccessGroup</key>
+	<string>$(AppIdentifierPrefix)app.hauptgang.shared</string>
+</dict>
+</plist>

--- a/hauptgang-ios/ImportRecipeExtension/ShareViewController.swift
+++ b/hauptgang-ios/ImportRecipeExtension/ShareViewController.swift
@@ -1,0 +1,170 @@
+import UIKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+@objc(ShareViewController)
+class ShareViewController: UIViewController {
+    private var importState: ImportState = .extracting
+    private var hostingController: UIHostingController<ImportRecipeView>?
+    private var importTask: Task<Void, Never>?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        extractURL()
+    }
+
+    deinit {
+        importTask?.cancel()
+    }
+
+    private func setupUI() {
+        let importView = makeImportView(state: importState)
+        let hostingController = UIHostingController(rootView: importView)
+        self.hostingController = hostingController
+
+        addChild(hostingController)
+        view.addSubview(hostingController.view)
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+        hostingController.didMove(toParent: self)
+    }
+
+    private func updateState(_ newState: ImportState) {
+        importState = newState
+        hostingController?.rootView = makeImportView(state: newState)
+    }
+
+    private func makeImportView(state: ImportState) -> ImportRecipeView {
+        ImportRecipeView(
+            state: state,
+            onClose: { [weak self] in self?.close() },
+            onOpenApp: { [weak self] in self?.openMainApp() }
+        )
+    }
+
+    private func extractURL() {
+        guard let extensionItem = extensionContext?.inputItems.first as? NSExtensionItem,
+              let attachments = extensionItem.attachments else {
+            updateState(.failed("No content found"))
+            return
+        }
+
+        importTask = Task {
+            if let url = await extractURLFromAttachments(attachments) {
+                await handleExtractedURL(url)
+            } else {
+                await MainActor.run {
+                    updateState(.failed("Could not extract URL"))
+                }
+            }
+        }
+    }
+
+    private func extractURLFromAttachments(_ attachments: [NSItemProvider]) async -> URL? {
+        let urlType = UTType.url.identifier
+        let plainTextType = UTType.plainText.identifier
+
+        for provider in attachments {
+            if provider.hasItemConformingToTypeIdentifier(urlType) {
+                if let url = await loadURL(from: provider, typeIdentifier: urlType) {
+                    return url
+                }
+            }
+        }
+
+        for provider in attachments {
+            if provider.hasItemConformingToTypeIdentifier(plainTextType) {
+                if let url = await loadURLFromPlainText(from: provider, typeIdentifier: plainTextType) {
+                    return url
+                }
+            }
+        }
+
+        return nil
+    }
+
+    private func loadURL(from provider: NSItemProvider, typeIdentifier: String) async -> URL? {
+        await withCheckedContinuation { continuation in
+            provider.loadItem(forTypeIdentifier: typeIdentifier, options: nil) { item, _ in
+                if let url = item as? URL {
+                    continuation.resume(returning: url)
+                } else if let nsurl = item as? NSURL, let url = nsurl as URL? {
+                    continuation.resume(returning: url)
+                } else if let data = item as? Data, let url = URL(dataRepresentation: data, relativeTo: nil) {
+                    continuation.resume(returning: url)
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+
+    private func loadURLFromPlainText(from provider: NSItemProvider, typeIdentifier: String) async -> URL? {
+        await withCheckedContinuation { continuation in
+            provider.loadItem(forTypeIdentifier: typeIdentifier, options: nil) { item, _ in
+                let text: String?
+                if let str = item as? String {
+                    text = str
+                } else if let data = item as? Data {
+                    text = String(data: data, encoding: .utf8)
+                } else {
+                    text = nil
+                }
+
+                if let text = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   let url = URL(string: text),
+                   url.scheme != nil {
+                    continuation.resume(returning: url)
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }
+    }
+
+    private func handleExtractedURL(_ url: URL) async {
+        await MainActor.run {
+            updateState(.importing(url))
+        }
+
+        guard await KeychainService.shared.getToken() != nil else {
+            await MainActor.run {
+                updateState(.notAuthenticated)
+            }
+            return
+        }
+
+        do {
+            _ = try await RecipeImportService.shared.importRecipe(from: url)
+            await MainActor.run {
+                updateState(.success)
+            }
+            try? await Task.sleep(for: .seconds(2))
+            await MainActor.run {
+                close()
+            }
+        } catch {
+            await MainActor.run {
+                updateState(.failed(error.localizedDescription))
+            }
+        }
+    }
+
+    private func openMainApp() {
+        guard let appURL = URL(string: "hauptgang://") else { return }
+        extensionContext?.open(appURL) { [weak self] _ in
+            self?.close()
+        }
+    }
+
+    private func close() {
+        importTask?.cancel()
+        extensionContext?.completeRequest(returningItems: nil, completionHandler: nil)
+    }
+}

--- a/hauptgang-ios/project.yml
+++ b/hauptgang-ios/project.yml
@@ -24,11 +24,43 @@ targets:
       INFOPLIST_FILE: Hauptgang/Resources/Info.plist
       ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
       ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+      CODE_SIGN_ENTITLEMENTS: Hauptgang/Hauptgang.entitlements
       CODE_SIGN_STYLE: Automatic
       DEVELOPMENT_TEAM: ""
       ENABLE_PREVIEWS: YES
       GENERATE_INFOPLIST_FILE: NO
       SWIFT_EMIT_LOC_STRINGS: YES
+    dependencies:
+      - target: ImportRecipeExtension
+        embed: true
+        codeSign: true
+        copyPhase:
+          destination: plugins
+          subpath: ""
+
+  ImportRecipeExtension:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: ImportRecipeExtension
+        excludes:
+          - "**/.DS_Store"
+      # Shared code from main app
+      - path: Hauptgang/Services/APIClient.swift
+      - path: Hauptgang/Services/KeychainService.swift
+      - path: Hauptgang/Models/APIError.swift
+      - path: Hauptgang/Models/User.swift
+      - path: Hauptgang/Utilities/Constants.swift
+      - path: Hauptgang/Models/ImportRecipeResponse.swift
+      - path: Hauptgang/Services/RecipeImportService.swift
+    settings:
+      PRODUCT_BUNDLE_IDENTIFIER: app.hauptgang.ios.share-extension
+      INFOPLIST_FILE: ImportRecipeExtension/Info.plist
+      CODE_SIGN_ENTITLEMENTS: ImportRecipeExtension/ImportRecipeExtension.entitlements
+      CODE_SIGN_STYLE: Automatic
+      DEVELOPMENT_TEAM: ""
+      SKIP_INSTALL: YES
+      GENERATE_INFOPLIST_FILE: NO
     dependencies: []
 
   HauptgangTests:

--- a/hauptgang-ios/share-extension-demo/Base.lproj/MainInterface.storyboard
+++ b/hauptgang-ios/share-extension-demo/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Share View Controller-->
+        <scene sceneID="ceB-am-kn3">
+            <objects>
+                <viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="1Xd-am-t49"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/hauptgang-ios/share-extension-demo/Info.plist
+++ b/hauptgang-ios/share-extension-demo/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/hauptgang-ios/share-extension-demo/ShareViewController.swift
+++ b/hauptgang-ios/share-extension-demo/ShareViewController.swift
@@ -1,0 +1,30 @@
+//
+//  ShareViewController.swift
+//  share-extension-demo
+//
+//  Created by Szymon Nastaly on 28.01.26.
+//
+
+import UIKit
+import Social
+
+class ShareViewController: SLComposeServiceViewController {
+
+    override func isContentValid() -> Bool {
+        // Do validation of contentText and/or NSExtensionContext attachments here
+        return true
+    }
+
+    override func didSelectPost() {
+        // This is called after the user selects Post. Do the upload of contentText and/or NSExtensionContext attachments.
+    
+        // Inform the host that we're done, so it un-blocks its UI. Note: Alternatively you could call super's -didSelectPost, which will similarly complete the extension context.
+        self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
+    }
+
+    override func configurationItems() -> [Any]! {
+        // To add configuration options via table cells at the bottom of the sheet, return an array of SLComposeSheetConfigurationItem here.
+        return []
+    }
+
+}

--- a/test/jobs/recipe_import_job_test.rb
+++ b/test/jobs/recipe_import_job_test.rb
@@ -50,6 +50,9 @@ class RecipeImportJobTest < ActiveSupport::TestCase
 
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
+    assert_not_nil @recipe.error_message
+    assert_includes @recipe.error_message, "example.com"
+    assert_includes @recipe.error_message, "not supported"
   end
 
   test "marks recipe as failed when no recipe data found" do
@@ -64,6 +67,9 @@ class RecipeImportJobTest < ActiveSupport::TestCase
 
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
+    assert_not_nil @recipe.error_message
+    assert_includes @recipe.error_message, "example.com"
+    assert_includes @recipe.error_message, "not supported"
   end
 
   test "does nothing when recipe no longer exists" do
@@ -94,5 +100,7 @@ class RecipeImportJobTest < ActiveSupport::TestCase
 
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
+    assert_not_nil @recipe.error_message
+    assert_includes @recipe.error_message, "example.com"
   end
 end

--- a/test/jobs/recipe_import_job_test.rb
+++ b/test/jobs/recipe_import_job_test.rb
@@ -51,8 +51,7 @@ class RecipeImportJobTest < ActiveSupport::TestCase
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
     assert_not_nil @recipe.error_message
-    assert_includes @recipe.error_message, "example.com"
-    assert_includes @recipe.error_message, "not supported"
+    assert_equal "Import from example.com failed.", @recipe.error_message
   end
 
   test "marks recipe as failed when no recipe data found" do
@@ -68,8 +67,7 @@ class RecipeImportJobTest < ActiveSupport::TestCase
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
     assert_not_nil @recipe.error_message
-    assert_includes @recipe.error_message, "example.com"
-    assert_includes @recipe.error_message, "not supported"
+    assert_equal "Import from example.com failed.", @recipe.error_message
   end
 
   test "does nothing when recipe no longer exists" do

--- a/test/jobs/recipe_text_extract_job_test.rb
+++ b/test/jobs/recipe_text_extract_job_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+class RecipeTextExtractJobTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:one)
+    @recipe = recipes(:one)
+    @recipe.update!(import_status: :pending, name: "Importing...")
+  end
+
+  test "updates recipe with extracted data on success" do
+    text = "Chocolate Cake\n\nIngredients:\n- 2 cups flour\n- 1 cup sugar\n\nInstructions:\n1. Mix dry ingredients\n2. Bake at 350F"
+
+    stub_llm_response(
+      name: "Chocolate Cake",
+      ingredients: [ "2 cups flour", "1 cup sugar" ],
+      instructions: [ "Mix dry ingredients", "Bake at 350F" ],
+      prep_time: 15,
+      cook_time: 30,
+      servings: 8,
+      notes: "A delicious family recipe"
+    )
+
+    RecipeTextExtractJob.perform_now(@user.id, @recipe.id, text)
+
+    @recipe.reload
+    assert_equal :completed, @recipe.import_status.to_sym
+    assert_equal "Chocolate Cake", @recipe.name
+    assert_equal [ "2 cups flour", "1 cup sugar" ], @recipe.ingredients
+    assert_equal [ "Mix dry ingredients", "Bake at 350F" ], @recipe.instructions
+    assert_equal 15, @recipe.prep_time
+    assert_equal 30, @recipe.cook_time
+    assert_equal 8, @recipe.servings
+    assert_equal "A delicious family recipe", @recipe.notes
+  end
+
+  test "does not set source_url since extraction is from raw text" do
+    text = "Simple Recipe\n\nIngredients:\n- 1 item\n\nDo the thing."
+    @recipe.update!(source_url: nil)
+
+    stub_llm_response(
+      name: "Simple Recipe",
+      ingredients: [ "1 item" ],
+      instructions: [ "Do the thing" ]
+    )
+
+    RecipeTextExtractJob.perform_now(@user.id, @recipe.id, text)
+
+    @recipe.reload
+    assert_equal :completed, @recipe.import_status.to_sym
+    assert_nil @recipe.source_url
+  end
+
+  test "marks recipe as failed when extraction fails" do
+    stub_llm_no_recipe_found
+
+    RecipeTextExtractJob.perform_now(@user.id, @recipe.id, "random text with no recipe")
+
+    @recipe.reload
+    assert_equal :failed, @recipe.import_status.to_sym
+  end
+
+  test "marks recipe as failed when LLM times out" do
+    stub_request(:post, LlmStubHelper::OPENROUTER_ENDPOINT)
+      .to_raise(Faraday::TimeoutError.new("execution expired"))
+
+    RecipeTextExtractJob.perform_now(@user.id, @recipe.id, "Some recipe text")
+
+    @recipe.reload
+    assert_equal :failed, @recipe.import_status.to_sym
+  end
+
+  test "does nothing when recipe no longer exists" do
+    deleted_id = @recipe.id
+    @recipe.destroy
+
+    assert_nothing_raised do
+      RecipeTextExtractJob.perform_now(@user.id, deleted_id, "Some text")
+    end
+  end
+
+  test "does nothing when user no longer exists" do
+    deleted_user_id = @user.id
+    @user.destroy
+
+    assert_nothing_raised do
+      RecipeTextExtractJob.perform_now(deleted_user_id, @recipe.id, "Some text")
+    end
+  end
+
+  test "does nothing when recipe is already completed" do
+    @recipe.update!(import_status: :completed, name: "Already Done")
+
+    RecipeTextExtractJob.perform_now(@user.id, @recipe.id, "New text")
+
+    @recipe.reload
+    assert_equal "Already Done", @recipe.name
+  end
+
+  test "marks recipe as failed on unexpected error and re-raises" do
+    # Stub RecipeLlmService.new to return a mock that raises on extract
+    mock_service = Minitest::Mock.new
+    mock_service.expect(:extract, nil) { raise StandardError.new("Unexpected") }
+
+    RecipeLlmService.stub(:new, mock_service) do
+      assert_raises(StandardError) do
+        RecipeTextExtractJob.perform_now(@user.id, @recipe.id, "Some text")
+      end
+    end
+
+    @recipe.reload
+    assert_equal :failed, @recipe.import_status.to_sym
+  end
+end

--- a/test/jobs/recipe_text_extract_job_test.rb
+++ b/test/jobs/recipe_text_extract_job_test.rb
@@ -57,6 +57,7 @@ class RecipeTextExtractJobTest < ActiveSupport::TestCase
 
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
+    assert_equal "Import failed - text doesn't contain a recipe", @recipe.error_message
   end
 
   test "marks recipe as failed when LLM times out" do
@@ -67,6 +68,7 @@ class RecipeTextExtractJobTest < ActiveSupport::TestCase
 
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
+    assert_equal "Import failed - text doesn't contain a recipe", @recipe.error_message
   end
 
   test "does nothing when recipe no longer exists" do
@@ -109,5 +111,6 @@ class RecipeTextExtractJobTest < ActiveSupport::TestCase
 
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
+    assert_equal "Import failed - text doesn't contain a recipe", @recipe.error_message
   end
 end

--- a/test/jobs/recipe_text_extract_job_test.rb
+++ b/test/jobs/recipe_text_extract_job_test.rb
@@ -57,7 +57,7 @@ class RecipeTextExtractJobTest < ActiveSupport::TestCase
 
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
-    assert_equal "Import failed - text doesn't contain a recipe", @recipe.error_message
+    assert_equal "Import failed.", @recipe.error_message
   end
 
   test "marks recipe as failed when LLM times out" do
@@ -68,7 +68,7 @@ class RecipeTextExtractJobTest < ActiveSupport::TestCase
 
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
-    assert_equal "Import failed - text doesn't contain a recipe", @recipe.error_message
+    assert_equal "Import failed.", @recipe.error_message
   end
 
   test "does nothing when recipe no longer exists" do
@@ -111,6 +111,6 @@ class RecipeTextExtractJobTest < ActiveSupport::TestCase
 
     @recipe.reload
     assert_equal :failed, @recipe.import_status.to_sym
-    assert_equal "Import failed - text doesn't contain a recipe", @recipe.error_message
+    assert_equal "Import failed.", @recipe.error_message
   end
 end

--- a/test/services/recipe_llm_service_test.rb
+++ b/test/services/recipe_llm_service_test.rb
@@ -1,0 +1,287 @@
+require "test_helper"
+
+class RecipeLlmServiceTest < ActiveSupport::TestCase
+  # Successful extraction
+
+  test "extracts recipe from text with webpage prompt type" do
+    text = "Chocolate Cake Recipe. Ingredients: 2 cups flour, 1 cup sugar. Instructions: Mix and bake."
+    stub_llm_response(
+      name: "Chocolate Cake",
+      ingredients: [ "2 cups flour", "1 cup sugar" ],
+      instructions: [ "Mix ingredients", "Bake at 350°F for 30 minutes" ],
+      prep_time: 15,
+      cook_time: 30,
+      servings: 8,
+      notes: "A delicious family recipe"
+    )
+
+    result = RecipeLlmService.new(text, prompt_type: :webpage, source_url: "https://example.com/recipe").extract
+
+    assert result.success?
+    assert_equal "Chocolate Cake", result.recipe_attributes[:name]
+    assert_equal [ "2 cups flour", "1 cup sugar" ], result.recipe_attributes[:ingredients]
+    assert_equal [ "Mix ingredients", "Bake at 350°F for 30 minutes" ], result.recipe_attributes[:instructions]
+    assert_equal 15, result.recipe_attributes[:prep_time]
+    assert_equal 30, result.recipe_attributes[:cook_time]
+    assert_equal 8, result.recipe_attributes[:servings]
+    assert_equal "A delicious family recipe", result.recipe_attributes[:notes]
+    assert_equal "https://example.com/recipe", result.recipe_attributes[:source_url]
+  end
+
+  test "extracts recipe from raw text with raw_text prompt type" do
+    text = <<~TEXT
+      Grandma's Apple Pie
+
+      Ingredients:
+      - 6 apples, sliced
+      - 1 cup sugar
+      - 2 pie crusts
+
+      Instructions:
+      1. Preheat oven to 375°F
+      2. Mix apples with sugar
+      3. Fill pie crust and cover
+      4. Bake for 45 minutes
+    TEXT
+
+    stub_llm_response(
+      name: "Grandma's Apple Pie",
+      ingredients: [ "6 apples, sliced", "1 cup sugar", "2 pie crusts" ],
+      instructions: [ "Preheat oven to 375°F", "Mix apples with sugar", "Fill pie crust and cover", "Bake for 45 minutes" ]
+    )
+
+    result = RecipeLlmService.new(text, prompt_type: :raw_text).extract
+
+    assert result.success?
+    assert_equal "Grandma's Apple Pie", result.recipe_attributes[:name]
+    assert_nil result.recipe_attributes[:source_url]
+  end
+
+  test "uses webpage prompt type by default" do
+    stub_llm_response(name: "Test Recipe", ingredients: [], instructions: [])
+
+    RecipeLlmService.new("Some text").extract
+
+    assert_requested(:post, LlmStubHelper::OPENROUTER_ENDPOINT) do |req|
+      body = JSON.parse(req.body)
+      prompt = body["messages"].last["content"]
+      prompt.include?("webpage content")
+    end
+  end
+
+  test "uses raw_text prompt when specified" do
+    stub_llm_response(name: "Test Recipe", ingredients: [], instructions: [])
+
+    RecipeLlmService.new("Some text", prompt_type: :raw_text).extract
+
+    assert_requested(:post, LlmStubHelper::OPENROUTER_ENDPOINT) do |req|
+      body = JSON.parse(req.body)
+      prompt = body["messages"].last["content"]
+      prompt.include?("Recipe text:")
+    end
+  end
+
+  test "handles minimal recipe data" do
+    stub_llm_response(
+      name: "Simple Dish",
+      ingredients: [ "1 ingredient" ],
+      instructions: [ "Do something" ]
+    )
+
+    result = RecipeLlmService.new("Simple Recipe", prompt_type: :webpage).extract
+
+    assert result.success?
+    assert_equal "Simple Dish", result.recipe_attributes[:name]
+    assert_nil result.recipe_attributes[:prep_time]
+    assert_nil result.recipe_attributes[:cook_time]
+    assert_nil result.recipe_attributes[:servings]
+    assert_nil result.recipe_attributes[:notes]
+  end
+
+  test "does not include source_url when not provided" do
+    stub_llm_response(name: "Test Recipe", ingredients: [], instructions: [])
+
+    result = RecipeLlmService.new("Some text").extract
+
+    assert result.success?
+    assert_not result.recipe_attributes.key?(:source_url)
+  end
+
+  # Argument validation
+
+  test "raises ArgumentError for invalid prompt_type" do
+    assert_raises(ArgumentError) do
+      RecipeLlmService.new("text", prompt_type: :invalid)
+    end
+  end
+
+  # Error handling
+
+  test "returns failure when LLM returns empty name" do
+    stub_llm_response(name: "", ingredients: [], instructions: [])
+
+    result = RecipeLlmService.new("Some random content").extract
+
+    assert_not result.success?
+    assert_equal :extraction_failed, result.error_code
+    assert_match(/could not identify recipe name/i, result.error)
+  end
+
+  test "returns failure when text is blank" do
+    result = RecipeLlmService.new("").extract
+
+    assert_not result.success?
+    assert_equal :extraction_failed, result.error_code
+    assert_match(/no text content/i, result.error)
+  end
+
+  test "returns failure when text is nil" do
+    result = RecipeLlmService.new(nil).extract
+
+    assert_not result.success?
+    assert_equal :extraction_failed, result.error_code
+    assert_match(/no text content/i, result.error)
+  end
+
+  test "returns failure when LLM returns nil content" do
+    stub_openrouter_api(response_body: { "choices" => [ { "message" => { "content" => nil } } ] })
+
+    result = RecipeLlmService.new("Some content").extract
+
+    assert_not result.success?
+    assert_equal :extraction_failed, result.error_code
+  end
+
+  test "handles LLM API timeout" do
+    stub_request(:post, LlmStubHelper::OPENROUTER_ENDPOINT)
+      .to_raise(Faraday::TimeoutError.new("execution expired"))
+
+    result = RecipeLlmService.new("Recipe content").extract
+
+    assert_not result.success?
+    assert_equal :llm_timeout, result.error_code
+    assert_match(/timed out/i, result.error)
+  end
+
+  test "handles LLM connection failure" do
+    stub_request(:post, LlmStubHelper::OPENROUTER_ENDPOINT)
+      .to_raise(Faraday::ConnectionFailed.new("connection refused"))
+
+    result = RecipeLlmService.new("Recipe content").extract
+
+    assert_not result.success?
+    assert_equal :llm_timeout, result.error_code
+  end
+
+  test "handles RubyLLM API error" do
+    stub_request(:post, LlmStubHelper::OPENROUTER_ENDPOINT)
+      .to_return(status: 401, body: { error: { message: "Invalid API key" } }.to_json)
+
+    result = RecipeLlmService.new("Recipe content").extract
+
+    assert_not result.success?
+    assert_equal :llm_error, result.error_code
+    assert_match(/api error/i, result.error)
+  end
+
+  test "handles unexpected errors gracefully" do
+    stub_request(:post, LlmStubHelper::OPENROUTER_ENDPOINT)
+      .to_return(status: 200, body: "not valid json at all")
+
+    result = RecipeLlmService.new("Recipe content").extract
+
+    assert_not result.success?
+    assert_equal :extraction_failed, result.error_code
+  end
+
+  # Text length limits
+
+  test "truncates text to maximum length" do
+    long_content = "Recipe content. " * 2000  # ~32,000 chars
+
+    stub_llm_response(name: "Long Recipe", ingredients: [], instructions: [])
+
+    RecipeLlmService.new(long_content).extract
+
+    assert_requested(:post, LlmStubHelper::OPENROUTER_ENDPOINT) do |req|
+      body = JSON.parse(req.body)
+      prompt = body["messages"].last["content"]
+      prompt.length < 20_000  # Some buffer for prompt template
+    end
+  end
+
+  # Partial data handling
+
+  test "handles empty ingredients array" do
+    stub_llm_response(name: "No Ingredients Recipe", ingredients: [], instructions: [ "Just do it" ])
+
+    result = RecipeLlmService.new("Recipe with no ingredients listed").extract
+
+    assert result.success?
+    assert_equal [], result.recipe_attributes[:ingredients]
+  end
+
+  test "handles empty instructions array" do
+    stub_llm_response(name: "No Instructions Recipe", ingredients: [ "1 cup flour" ], instructions: [])
+
+    result = RecipeLlmService.new("Recipe with no instructions").extract
+
+    assert result.success?
+    assert_equal [], result.recipe_attributes[:instructions]
+  end
+
+  test "normalizes array elements by stripping whitespace" do
+    stub_llm_response(
+      name: "Whitespace Recipe",
+      ingredients: [ "  flour  ", "\nsugar\n", "  " ],
+      instructions: [ "  Step 1  ", "" ]
+    )
+
+    result = RecipeLlmService.new("Recipe").extract
+
+    assert result.success?
+    assert_equal [ "flour", "sugar" ], result.recipe_attributes[:ingredients]
+    assert_equal [ "Step 1" ], result.recipe_attributes[:instructions]
+  end
+
+  test "handles non-array ingredients gracefully" do
+    stub_llm_response(
+      name: "Bad Format Recipe",
+      ingredients: "not an array",
+      instructions: [ "Step 1" ]
+    )
+
+    result = RecipeLlmService.new("Recipe").extract
+
+    assert result.success?
+    assert_equal [], result.recipe_attributes[:ingredients]
+  end
+
+  test "strips whitespace from notes" do
+    stub_llm_response(
+      name: "Notes Recipe",
+      ingredients: [],
+      instructions: [],
+      notes: "  Some notes with whitespace  "
+    )
+
+    result = RecipeLlmService.new("Recipe").extract
+
+    assert result.success?
+    assert_equal "Some notes with whitespace", result.recipe_attributes[:notes]
+  end
+
+  test "returns nil for blank notes" do
+    stub_llm_response(
+      name: "Empty Notes Recipe",
+      ingredients: [],
+      instructions: [],
+      notes: "   "
+    )
+
+    result = RecipeLlmService.new("Recipe").extract
+
+    assert result.success?
+    assert_nil result.recipe_attributes[:notes]
+  end
+end


### PR DESCRIPTION
## Summary

Adds the ability to delete recipes and improves handling of failed imports by showing them as dismissible error banners.

## Rails Changes

- **DELETE /api/v1/recipes/:id** — New endpoint for recipe deletion
- **Security fix** — `cover_image_url` now returns relative paths instead of using `request.base_url` (prevents host header injection)
- **Performance** — `track_failed_recipe_fetches` uses single `update_all` query instead of N updates
- **Error handling** — Added `RecordNotDestroyed` rescue in destroy action
- **Simplified error messages** — Shortened failed import messages

## iOS Changes

- **Failed import banners** — Failed recipes now display as floating error banners at the bottom of the recipe list
- **Swipe to dismiss** — Banners can be swiped away or auto-dismiss after 5 seconds
- **Optimistic delete** — Local deletion happens immediately, server delete runs in background
- **404 handling** — Treats 404 on delete as success (server may have auto-cleaned)
- **Concurrency guard** — Prevents overlapping `refreshRecipes` calls
- **Relative URL support** — `Constants.API.resolveURL` helper for image paths

## Tests Added

### Rails
- Destroy returns 204 on success
- Destroy returns 404 for non-existent recipe
- Cannot delete another user's recipe
- Destroy requires authentication

### iOS
- `dismissFailedRecipe` deletes from repository
- `dismissFailedRecipe` calls server delete
- Server failure still removes locally
- `failedRecipes` / `successfulRecipes` filtering
- Concurrency guard skips when loading
- `Constants.API.resolveURL` (relative/absolute URLs)