### PR TITLE
chore: refresh dependencies, including sentry 7.0 and image_processing 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,10 @@ gem "kamal", require: false
 gem "thruster", require: false
 
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-gem "image_processing", "~> 1.2"
+gem "image_processing", "~> 2.1"
+# image_processing 2.0 made the backends soft dependencies; Rails defaults to the
+# vips processor and the Dockerfile installs libvips, so declare ruby-vips here.
+gem "ruby-vips"
 
 # S3-compatible storage (Hetzner Object Storage) [https://github.com/aws/aws-sdk-ruby]
 gem "aws-sdk-s3", require: false
@@ -93,8 +96,7 @@ end
 group :test do
   # System testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
-  # 4.45+ regressed: chromedriver launched without the Selenium Manager browser path
-  gem "selenium-webdriver", "< 4.45"
+  gem "selenium-webdriver"
 
   # HTTP request stubbing for testing [https://github.com/bblimke/webmock]
   gem "webmock"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
     ast (2.4.3)
     auth-sanitizer (0.2.3)
       version_gem (~> 1.1, >= 1.1.14)
-    avo (4.1.15)
+    avo (4.2.0)
       actionview (>= 6.1)
       active_link_to
       activerecord (>= 6.1)
@@ -108,7 +108,7 @@ GEM
     avo-icons (0.2.1)
       inline_svg
     aws-eventstream (1.4.0)
-    aws-partitions (1.1282.0)
+    aws-partitions (1.1283.0)
     aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
@@ -132,7 +132,7 @@ GEM
     bigdecimal (4.1.2)
     bindata (3.0.0)
     bindex (0.8.1)
-    bootsnap (1.25.0)
+    bootsnap (1.26.0)
       msgpack (~> 1.5)
     brakeman (8.0.6)
       racc
@@ -165,7 +165,7 @@ GEM
     ed25519 (1.4.0)
     erb (6.0.7)
     erubi (1.13.1)
-    et-orbi (1.4.1)
+    et-orbi (1.4.2)
       tzinfo
     event_stream_parser (1.0.0)
     faraday (2.14.3)
@@ -198,9 +198,7 @@ GEM
     http-2 (1.2.2)
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    image_processing (1.14.0)
-      mini_magick (>= 4.9.5, < 6)
-      ruby-vips (>= 2.0.17, < 3)
+    image_processing (2.1.0)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -260,10 +258,8 @@ GEM
       net-smtp
     marcel (1.2.1)
     matrix (0.4.3)
-    meta-tags (2.23.0)
+    meta-tags (2.24.0)
       actionpack (>= 6.0.0)
-    mini_magick (5.3.3)
-      logger
     mini_mime (1.1.5)
     minitest (6.0.6)
       drb (~> 2.0)
@@ -468,18 +464,18 @@ GEM
       ruby_llm-schema (~> 0)
       zeitwerk (~> 2)
     ruby_llm-schema (0.4.0)
-    rubyzip (3.5.0)
+    rubyzip (3.6.0)
     securerandom (0.4.1)
-    selenium-webdriver (4.44.0)
+    selenium-webdriver (4.48.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
-    sentry-rails (6.7.0)
+    sentry-rails (7.0.0)
       railties (>= 5.2.0)
-      sentry-ruby (~> 6.7.0)
-    sentry-ruby (6.7.0)
+      sentry-ruby (~> 7.0.0)
+    sentry-ruby (7.0.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
@@ -592,7 +588,7 @@ DEPENDENCIES
   debug
   faraday
   faraday-follow_redirects
-  image_processing (~> 1.2)
+  image_processing (~> 2.1)
   importmap-rails
   jbuilder
   jwt (~> 3.2)
@@ -610,8 +606,9 @@ DEPENDENCIES
   rails (~> 8.1.3)
   ransack
   rubocop-rails-omakase
+  ruby-vips
   ruby_llm
-  selenium-webdriver (< 4.45)
+  selenium-webdriver
   sentry-rails
   sentry-ruby
   solid_cable

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -4,7 +4,6 @@ Sentry.init do |config|
   config.traces_sample_rate = 0.1
   config.profiles_sample_rate = 0.1
 
-  config.enable_logs = true
   config.enabled_environments = %w[production]
 
   # GDPR: do not store PII


### PR DESCRIPTION
Clears the stalled Dependabot backlog and brings the lockfile current.

## Why Dependabot had stalled

Ten stale bundler PRs (#63–#82) filled `open-pull-requests-limit: 10`, so **no bundler update had been proposed since 2026-05-22** — while GitHub Actions PRs kept flowing (#83, #84 in June). Every one of the ten was superseded by `main`, e.g. #82 proposed bootsnap 1.24.5 against 1.25.0, and #63 proposed avo 3.31.2 long after the Gemfile moved to `~> 4.0`. All ten are now closed, which unjams the queue.

## Majors that needed code changes

**sentry 6.7 → 7.0** removes `config.enable_logs` outright. It was set in `config/initializers/sentry.rb`, so `Sentry.init` would have raised `NoMethodError` at boot in *every* environment:

```
enable_logs= RAISES NoMethodError: undefined method 'enable_logs=' for an instance of Sentry::Configuration
```

Structured logging is now always available via `Sentry.logger`, which `recipe_import_job` and `recipe_content_import_job` already use, so removing the line preserves behaviour.

`send_default_pii = false` is deprecated in favour of `data_collection`, but still honoured — `DataCollection.backfill` maps it to `user_info = false`, cookies off, header deny-lists and empty bodies. Keeping the one-liner retains the GDPR intent; migrating can wait for 8.0.

**image_processing 1.14 → 2.1** makes mini_magick/ruby-vips soft dependencies, so `ruby-vips` is declared explicitly. Rails defaults to the vips processor and the Dockerfile installs `libvips`; `mini_magick` drops out of the lockfile as a result. `resize_to_limit`, `format:` and `saver:` are unchanged, so the recipe cover variants are unaffected.

## Watch this one

`selenium-webdriver` was pinned `< 4.45` for a chromedriver browser-path regression. 4.48 passes the system suite locally, but CI runs on Linux against the runner’s preinstalled Chrome with no explicit setup step — which is the environment the pin was about. **If system tests fail here, restore the pin**; that is the only change in this PR that should be suspect.

## Left out

`marcel` 2.x and `ruby_llm-schema` 1.0 are pinned upstream by `activestorage (~> 1.0)` and `ruby_llm (~> 0)`. Tracked in #90 and #91.

## Verification

`bin/ci` green: 284 files no offenses, no vulnerabilities, 914 runs / 2458 assertions / 0 failures, 9 system tests / 0 failures.

Note the system suite is independently flaky — unmodified `main` failed 1 run in 4 (`signing in lands on the recipe grid`, `cmd-K focuses the search field`). Pre-existing, unrelated to these bumps, filed as #89.

https://claude.ai/code/session_01NJSH5pMrH3UMmKuU17Qu7s
